### PR TITLE
Task #15 - Plugin to support Java projects

### DIFF
--- a/src/main/scala/io/kevinlee/sbt/devoops/DevOopsJavaPlugin.scala
+++ b/src/main/scala/io/kevinlee/sbt/devoops/DevOopsJavaPlugin.scala
@@ -1,0 +1,51 @@
+package io.kevinlee.sbt.devoops
+
+import sbt.Keys._
+import sbt._
+import sbt.plugins.JvmPlugin
+
+/**
+  * @author Kevin Lee
+  * @since 2018-12-30
+  */
+object DevOopsJavaPlugin extends AutoPlugin {
+  // $COVERAGE-OFF$
+
+  override def requires: JvmPlugin.type = plugins.JvmPlugin
+
+  /**
+    *  To use this plugin, add the following line to `build.sbt`.
+    * {{{
+    * enablePlugins(DevOopsJavaPlugin)
+    * }}}
+    */
+  override def trigger: PluginTrigger = noTrigger
+
+  object autoImport {
+
+    lazy val javaVersion: SettingKey[String] =
+      settingKey[String]("The Java version for the Java Project")
+
+  }
+
+  import autoImport._
+
+  override lazy val projectSettings: Seq[Setting[_]] = Seq(
+
+    javaVersion := "1.8"
+    /*
+     * crossPaths and autoScalaLibrary should be false for Java project.
+     */
+  , crossPaths := false
+  , autoScalaLibrary := false
+
+  , javacOptions ++= Seq(
+      "-source", javaVersion.value
+    , "-target", javaVersion.value
+    , "-Xlint:unchecked"
+    , "-encoding", "UTF-8"
+    )
+  )
+
+  // $COVERAGE-ON$
+}


### PR DESCRIPTION
Summary
=======
Close #15 - Plugin to support Java projects
***
Added:
------
- `DevOopsJavaPlugin` for Java project
- `javaVersion` setting
- set `crossPaths` and `autoScalaLibrary` to false
- default `javacOptions`: `-source` and `-target` set to the `javaVersion` above, `-Xlint:unchecked`, and set `-encoding` to `UTF-8` 
