### PR TITLE
git fetch tags and other git command helpers

### DIFF
--- a/src/main/scala/io/kevinlee/git/Git.scala
+++ b/src/main/scala/io/kevinlee/git/Git.scala
@@ -28,11 +28,14 @@ object Git {
         Left(errorHandler(code, error))
     }
 
+  def git(baseDir: File, command: String, args: String*): ProcessResult =
+    SysProcess.run(
+      SysProcess.process(Some(baseDir), "git" :: command :: args.toList)
+    )
+
   def currentBranchName(baseDir: File): Either[GitCommandError, GitCommandResult] =
     ProcessResult.toEither(
-      SysProcess.run(
-        SysProcess.process(Some(baseDir), "git", "rev-parse", "--abbrev-ref", "HEAD")
-      )
+      git(baseDir, "rev-parse", "--abbrev-ref", "HEAD")
     )(fromProcessResultToEither(
       r => GitCommandResult.gitCurrentBranchName(BranchName(r.mkString.trim))
     , (code, err) => GitCommandError.gitCurrentBranchError(code, err)
@@ -61,9 +64,7 @@ object Git {
 
   def checkout(branchName: BranchName, baseDir: File): Either[GitCommandError, GitCommandResult] =
     ProcessResult.toEither(
-      SysProcess.run(
-        SysProcess.process(Some(baseDir), "git", "checkout", branchName.value)
-      )
+      git(baseDir, "checkout", branchName.value)
     )(fromProcessResultToEither(
       r => GitCommandResult.gitCheckoutResult(r.mkString("\n"))
     , (code, err) => GitCommandError.gitCheckoutError(code, err)
@@ -71,9 +72,7 @@ object Git {
 
   def tag(tagName: TagName, baseDir: File): Either[GitCommandError, GitCommandResult] =
     ProcessResult.toEither(
-      SysProcess.run(
-        SysProcess.process(Some(baseDir), "git", "tag", tagName.name)
-      )
+      git(baseDir, "tag", tagName.name)
     )(fromProcessResultToEither(
       r => GitCommandResult.gitTagResult(r.mkString("\n"))
     , (code, err) => GitCommandError.gitTagError(code, err)
@@ -81,7 +80,7 @@ object Git {
 
   def tagWithDescription(tagName: TagName, description: Description, baseDir: File): Either[GitCommandError, GitCommandResult] =
     ProcessResult.toEither(
-      SysProcess.run(SysProcess.process(Some(baseDir), "git", "tag", "-a", tagName.name, "-m", description.value))
+      git(baseDir, "tag", "-a", tagName.name, "-m", description.value)
     )(fromProcessResultToEither(
       r => GitCommandResult.gitTagResult(r.mkString("\n"))
     , (code, err) => GitCommandError.gitTagError(code, err)

--- a/src/main/scala/io/kevinlee/git/GitCommandError.scala
+++ b/src/main/scala/io/kevinlee/git/GitCommandError.scala
@@ -12,6 +12,7 @@ object GitCommandError {
   final case class GitUnexpectedCommandResultError(gitCommandResult: GitCommandResult, expectedResult: String) extends GitCommandError
   final case class GitCurrentBranchError(code: Int, error: String) extends GitCommandError
   final case class GitCheckoutError(code: Int, error: String) extends GitCommandError
+  final case class GitFetchError(code: Int, error: String, arg: Option[String]) extends GitCommandError
   final case class GitTagError(code: Int, error: String) extends GitCommandError
 
   def gitUnexpectedCommandResultError(gitCommandResult: GitCommandResult, expectedResult: String): GitCommandError =
@@ -23,6 +24,9 @@ object GitCommandError {
   def gitCheckoutError(code: Int, error: String): GitCommandError =
     GitCheckoutError(code, error)
 
+  def gitFetchError(code: Int, error: String, arg: Option[String]): GitCommandError =
+    GitFetchError(code, error, arg)
+
   def gitTagError(code: Int, error: String): GitCommandError =
     GitTagError(code, error)
 
@@ -31,20 +35,23 @@ object GitCommandError {
 
   def render(gitError: GitCommandError): String = gitError match {
     case GitUnexpectedCommandResultError(gitCommandResult, expectedResult) =>
-      s"""Unexpected git command result]
+      s"""Unexpected git command result
          |expected: $expectedResult
          |---
          |  actual: ${GitCommandResult.render(gitCommandResult)}
          |""".stripMargin
 
+    case GitCurrentBranchError(code, error) =>
+      s"Error] Git getting the current branch: ${renderCodeAndError(code, error)}"
+
     case GitCheckoutError(code, error) =>
-      s"failed] Git checkout: ${renderCodeAndError(code, error)}"
+      s"Error] Git checkout: ${renderCodeAndError(code, error)}"
+
+    case GitFetchError(code, error, arg) =>
+      s"Error] Git fetch${arg.fold("")(a => s" $a")}: ${renderCodeAndError(code, error)}"
 
     case GitTagError(code, error) =>
-      s"failed] Git tag: ${renderCodeAndError(code, error)}"
-
-    case GitCurrentBranchError(code, error) =>
-      s"failed] Git getting the current branch: ${renderCodeAndError(code, error)}"
+      s"Error] Git tag: ${renderCodeAndError(code, error)}"
   }
 
   // $COVERAGE-ON$

--- a/src/main/scala/io/kevinlee/git/GitCommandResult.scala
+++ b/src/main/scala/io/kevinlee/git/GitCommandResult.scala
@@ -1,5 +1,7 @@
 package io.kevinlee.git
 
+import io.kevinlee.git.Git.{BranchName, TagName}
+
 sealed trait GitCommandResult
 
 /**
@@ -9,29 +11,36 @@ sealed trait GitCommandResult
 object GitCommandResult {
   // $COVERAGE-OFF$
 
-  final case class GitCurrentBranchName(name: Git.BranchName) extends GitCommandResult
-  final case class GitCheckoutResult(result: String) extends GitCommandResult
-  final case class GitTagResult(result: String) extends GitCommandResult
+  final case class GitCurrentBranchName(name: BranchName) extends GitCommandResult
+  final case class GitCheckoutResult(name: BranchName) extends GitCommandResult
+  final case class GitFetchResult(arg: Option[String]) extends GitCommandResult
+  final case class GitTagResult(tagName: TagName) extends GitCommandResult
 
-  def gitCurrentBranchName(name: Git.BranchName): GitCommandResult =
+  def gitCurrentBranchName(name: BranchName): GitCommandResult =
     GitCurrentBranchName(name)
 
-  def gitCheckoutResult(result: String): GitCommandResult =
-    GitCheckoutResult(result)
+  def gitCheckoutResult(name: BranchName): GitCommandResult =
+    GitCheckoutResult(name)
 
-  def gitTagResult(result: String): GitCommandResult =
-    GitTagResult(result)
+  def gitFetchResult(arg: Option[String]): GitCommandResult =
+    GitFetchResult(arg)
+
+  def gitTagResult(tagName: TagName): GitCommandResult =
+    GitTagResult(tagName)
 
   def render(gitCommandResult: GitCommandResult): String = gitCommandResult match {
 
-    case GitCurrentBranchName(Git.BranchName(name)) =>
-      s"git current branch name: $name"
+    case GitCurrentBranchName(BranchName(branchName)) =>
+      s"git current branch name: $branchName"
 
-    case GitCheckoutResult(result) =>
-      s"git checkout has finished: $result"
+    case GitCheckoutResult(BranchName(branchName)) =>
+      s"git checkout $branchName"
 
-    case GitTagResult(result) =>
-      s"git tag has finished: $result"
+    case GitFetchResult(arg) =>
+      s"git fetch${arg.fold("")(a => s" $a")}"
+
+    case GitTagResult(TagName(tagName)) =>
+      s"git tag $tagName"
 
   }
 

--- a/src/main/scala/io/kevinlee/git/sysProcess.scala
+++ b/src/main/scala/io/kevinlee/git/sysProcess.scala
@@ -6,6 +6,7 @@ import io.kevinlee.CommonPredef._
 
 import scala.sys.process.ProcessLogger
 
+// $COVERAGE-OFF$
 /**
   * @author Kevin Lee
   * @since 2019-01-01
@@ -64,7 +65,7 @@ sealed trait SysProcess
 object SysProcess {
   final case class SingleSysProcess(commands: Seq[String], baseDir: Option[File]) extends SysProcess
 
-  def process(baseDir: Option[File], commands: String*): SysProcess =
+  def process(baseDir: Option[File], commands: Seq[String]): SysProcess =
     SingleSysProcess(commands, baseDir)
 
   def run(sysProcess: SysProcess): ProcessResult = sysProcess match {

--- a/src/main/scala/io/kevinlee/sbt/devoops/data/SbtTask.scala
+++ b/src/main/scala/io/kevinlee/sbt/devoops/data/SbtTask.scala
@@ -9,7 +9,7 @@ import io.kevinlee.git.{GitCommandError, GitCommandResult}
 object SbtTask {
   // $COVERAGE-OFF$
 
-  def handleGitCommandTask(gitCommandTaskResult: Either[GitCommandError, GitCommandResult]): Unit =
+  def handleGitCommandTask(gitCommandTaskResult: Either[GitCommandError, Seq[GitCommandResult]]): Unit =
     gitCommandTaskResult
       .left.map(SbtTaskError.gitCommandTaskError)
       .right.map(SbtTaskResult.gitCommandTaskResult)

--- a/src/main/scala/io/kevinlee/sbt/devoops/data/SbtTaskError.scala
+++ b/src/main/scala/io/kevinlee/sbt/devoops/data/SbtTaskError.scala
@@ -26,7 +26,7 @@ object SbtTaskError {
       GitCommandError.render(err)
 
     case GitTaskError(cause) =>
-      s"git task has failed: $cause"
+      s"task failed> git command: $cause"
 
   }
 

--- a/src/main/scala/io/kevinlee/sbt/devoops/data/SbtTaskResult.scala
+++ b/src/main/scala/io/kevinlee/sbt/devoops/data/SbtTaskResult.scala
@@ -11,14 +11,18 @@ sealed trait SbtTaskResult
 object SbtTaskResult {
   // $COVERAGE-OFF$
 
-  final case class GitCommandTaskResult(gitCommandResult: GitCommandResult) extends SbtTaskResult
+  final case class GitCommandTaskResult(gitCommandResult: Seq[GitCommandResult]) extends SbtTaskResult
 
-  def gitCommandTaskResult(gitCommandResult: GitCommandResult): SbtTaskResult =
+  def gitCommandTaskResult(gitCommandResult: Seq[GitCommandResult]): SbtTaskResult =
     GitCommandTaskResult(gitCommandResult)
 
   def render(sbtTaskResult: SbtTaskResult): String = sbtTaskResult match {
-    case GitCommandTaskResult(gitCommandResult) =>
-      s"sbt task done: ${GitCommandResult.render(gitCommandResult)}"
+    case GitCommandTaskResult(gitCommandResults) =>
+      val delimiter = "  >> "
+      s"""
+         |task success> git commands
+         |${gitCommandResults.map(GitCommandResult.render).mkString(delimiter, s"\n$delimiter", "")}
+         |""".stripMargin
   }
 
   def consolePrintln(sbtTaskResult: SbtTaskResult): Unit =


### PR DESCRIPTION
Summary
=======
Task #23 - Tag when merge into release branch happens (work in progress)

## Added: 
* a method to run generic git commands
* git fetch --tags before tagging

## Changed:
* result and error message
* Now the git command results are accumulated (the first error causes the failure just like before)
