### PR TITLE
sbt-devoops v1.0.3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,4 +55,4 @@ jobs:
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
         run: |
           export CI_BRANCH="${GITHUB_REF#refs/heads/}"
-          .github/workflows/sbt-build.sh 2.12.10 1.3.3
+          .github/workflows/sbt-build.sh 2.12.10 1.3.4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,13 +33,13 @@ jobs:
     - name: sbt test and packagedArtifacts for Scala 2.12 and sbt 1.x
       run: |
         echo "Run] sbt packagedArtifacts"
-        echo 'sbt -J-Xmx2048m "++2.12.10!" "^^1.3.3" clean test packagedArtifacts'
-        sbt -J-Xmx2048m "++2.12.10!" "^^1.3.3" clean test packagedArtifacts
+        echo 'sbt -J-Xmx2048m "++2.12.10!" "^^1.3.4" clean test packagedArtifacts'
+        sbt -J-Xmx2048m "++2.12.10!" "^^1.3.4" clean test packagedArtifacts
     - name: sbt Publish for Scala 2.12 and sbt 1.x
       env:
         BINTRAY_USER: ${{ secrets.BINTRAY_USER }}
         BINTRAY_PASS: ${{ secrets.BINTRAY_PASS }}
       run: |
         echo "Run] sbt publish"
-        echo 'sbt -J-Xmx2048m "++2.12.10!" "^^1.3.3" clean publish'
-        sbt -J-Xmx2048m "++2.12.10!" "^^1.3.3" clean publish
+        echo 'sbt -J-Xmx2048m "++2.12.10!" "^^1.3.4" clean publish'
+        sbt -J-Xmx2048m "++2.12.10!" "^^1.3.4" clean publish

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ SBT Plugin to help CI and CD
 # Get sbt-devoops
 In the `project/plugins.sbt`, add the following line,
 ```sbt
-addSbtPlugin("io.kevinlee" % "sbt-devoops" % "1.0.2")
+addSbtPlugin("io.kevinlee" % "sbt-devoops" % "1.0.3")
 ```
 
 # DevOopsScalaPlugin

--- a/changelogs/1.0.3.md
+++ b/changelogs/1.0.3.md
@@ -1,0 +1,11 @@
+## [1.0.3](https://github.com/Kevin-Lee/sbt-devoops/issues?utf8=✓&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone7) - 2019-12-06
+
+### Done
+* Replace `SemanticVersion` with `just-semver` lib (#105)
+* Upgrade sbt for building `sbt-devoops` (#111)
+* Add `partial-unification` to `scalacOptions` (#117)
+* Upgrade sbt to `1.3.3` (#107)
+* Upgrade sbt to `1.3.4` (#119)
+
+### Fixed
+* Remove `javacOptions` causing problems (#113)

--- a/project/ProjectInfo.scala
+++ b/project/ProjectInfo.scala
@@ -6,7 +6,7 @@ import wartremover.{Wart, Warts}
   */
 object ProjectInfo {
 
-  val ProjectVersion: String = "1.0.2"
+  val ProjectVersion: String = "1.0.3"
 
   val commonScalacOptions: Seq[String] = Seq(
       "-deprecation"


### PR DESCRIPTION
# sbt-devoops v1.0.3
## [1.0.3](https://github.com/Kevin-Lee/sbt-devoops/issues?utf8=✓&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone7) - 2019-12-06

### Done
* Replace `SemanticVersion` with `just-semver` lib (#105)
* Upgrade sbt for building `sbt-devoops` (#111)
* Add `partial-unification` to `scalacOptions` (#117)
* Upgrade sbt to `1.3.3` (#107)
* Upgrade sbt to `1.3.4` (#119)

### Fixed
* Remove `javacOptions` causing problems (#113)
