### PR TITLE
Issue #187 - Change DevOopsGitReleasePlugin to DevOopsGitHubReleasePlugin

### DIFF
--- a/src/main/scala/kevinlee/sbt/devoops/DevOopsGitHubReleasePlugin.scala
+++ b/src/main/scala/kevinlee/sbt/devoops/DevOopsGitHubReleasePlugin.scala
@@ -27,7 +27,7 @@ import scala.concurrent.duration._
 /** @author Kevin Lee
   * @since 2019-01-01
   */
-object DevOopsGitReleasePlugin extends AutoPlugin {
+object DevOopsGitHubReleasePlugin extends AutoPlugin {
 
   // $COVERAGE-OFF$
   override def requires: Plugins      = empty


### PR DESCRIPTION
# Summary
Issue #187 - Change `DevOopsGitReleasePlugin` to `DevOopsGitHubReleasePlugin`