### PR TITLE
sbt-devoops v2.0.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         scala:
-          - { version: "2.12.11", binary-version: "2.12", java-version: "11", sbt-version: "1.3.13",  coveralls: "coveralls" }
+          - { version: "2.12.12", binary-version: "2.12", java-version: "11", sbt-version: "1.3.13",  coveralls: "coveralls" }
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         scala:
-          - { version: "2.12.11", binary-version: "2.12", java-version: "11", sbt-version: "1.3.13" }
+          - { version: "2.12.12", binary-version: "2.12", java-version: "11", sbt-version: "1.3.13" }
 
     steps:
       - uses: actions/checkout@v2

--- a/changelogs/2.0.0.md
+++ b/changelogs/2.0.0.md
@@ -1,0 +1,55 @@
+## [2.0.0](https://github.com/Kevin-Lee/sbt-devoops/issues?utf8=✓&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone8+-label%3Adeclined) - 2021-02-17
+
+### Done
+* Support release to upload only artifacts (#125) ⚠️
+* Replace `master` branch with `main` branch (#126)
+* Create [document website](https://sbt-devoops.kevinly.dev) (#130)
+* Replace `Just FP` with `Cats` (#138)
+* **Drop sbt `0.13.x` support** (#141) ⚠️
+* Adopt `Cats Effect` (#143)
+* Use `http4s` instead of `github-api` (#146)
+* GitHub release tasks should create a release without uploading artifacts (#163) ⚠️
+* Change the default branch for `gitTagFrom` from `mater` to `main` (#167) ⚠️
+* Add `SettingKey` for GitHub request timeout (#169)
+* re-package from `kevinlee.sbt.devoops` to `devoops` (#173) ⚠️
+* `scalacOptions` for Scala `2.13.3` and higher (#175)
+* Remove `OldGitHubApi` (#177)
+* Add a way to avoid the abuse rate limits in GitHub API (#179)
+* Change `DevOopsGitReleasePlugin` to `DevOopsGitHubReleasePlugin` (#187) ⚠️
+* Add `@deprecated` `Plugin`s as a guide to use the new ones (#191) ⚠️
+* Add log level for `sbt-devoops` tasks (#194)
+* Add `devOops` prefix to avoid any potential naming conflicts with other plugins (#195) ⚠️
+* Create versioned doc sites (#199)
+
+⚠️: Breaking changes
+
+
+### Breaking Changes
+sbt-devoops no longer supports sbt 0.13 so please use sbt 1.0+
+* **Drop sbt `0.13.x` support** (#141) ⚠️
+
+***
+**WARNING!!!**
+
+All `sbt-devoops` settings and tasks now have `devOops` prefix.
+* Add `devOops` prefix to avoid any potential naming conflicts with other plugins (#195) ⚠️
+
+***
+
+`gitHubRelease` and `gitTagAndGitHubRelease` which are now `devOopsGitHubRelease` and `devOopsGitTagAndGitHubRelease` 
+do  not upload artifacts anymore. These create GitHub releases without any artifacts. 
+These do upload the changelog though. To upload artifacts, please use `devOopsGitHubReleaseUploadArtifacts` task.
+* Support release to upload only artifacts (#125) ⚠️
+* GitHub release tasks should create a release without uploading artifacts (#163) ⚠️
+
+***
+The default branch used to tag changed from `master` to `main` so if you want to use `master`, 
+please set the value of `devOopsGitTagFrom` which was `gitTagFrom` in the older version like `1.0.3`.
+* Change the default branch for `devOopsGitTagFrom` from `mater` to `main` (#167) ⚠️
+
+***
+
+`DevOopsGitReleasePlugin` => `DevOopsGitHubReleasePlugin` and the `kevinlee.sbt.devoops` package is now just `devoops`.
+* re-package from `kevinlee.sbt.devoops` to `devoops` (#173) ⚠️
+* Change `DevOopsGitReleasePlugin` to `DevOopsGitHubReleasePlugin` (#187) ⚠️
+* Add `@deprecated` `Plugin`s as a guide to use the new ones (#191) ⚠️

--- a/project/ProjectInfo.scala
+++ b/project/ProjectInfo.scala
@@ -6,7 +6,7 @@ import wartremover.{Wart, Warts}
   */
 object ProjectInfo {
 
-  val ProjectVersion: String = "1.0.3"
+  val ProjectVersion: String = "2.0.0"
 
   val commonScalacOptions: Seq[String] = Seq(
       "-deprecation"


### PR DESCRIPTION
# sbt-devoops v2.0.0
## [2.0.0](https://github.com/Kevin-Lee/sbt-devoops/issues?utf8=✓&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone8+-label%3Adeclined) - 2021-02-17

### Done
* Support release to upload only artifacts (#125) ⚠️
* Replace `master` branch with `main` branch (#126)
* Create [document website](https://sbt-devoops.kevinly.dev) (#130)
* Replace `Just FP` with `Cats` (#138)
* **Drop sbt `0.13.x` support** (#141) ⚠️
* Adopt `Cats Effect` (#143)
* Use `http4s` instead of `github-api` (#146)
* GitHub release tasks should create a release without uploading artifacts (#163) ⚠️
* Change the default branch for `gitTagFrom` from `mater` to `main` (#167) ⚠️
* Add `SettingKey` for GitHub request timeout (#169)
* re-package from `kevinlee.sbt.devoops` to `devoops` (#173) ⚠️
* `scalacOptions` for Scala `2.13.3` and higher (#175)
* Remove `OldGitHubApi` (#177)
* Add a way to avoid the abuse rate limits in GitHub API (#179)
* Change `DevOopsGitReleasePlugin` to `DevOopsGitHubReleasePlugin` (#187) ⚠️
* Add `@deprecated` `Plugin`s as a guide to use the new ones (#191) ⚠️
* Add log level for `sbt-devoops` tasks (#194)
* Add `devOops` prefix to avoid any potential naming conflicts with other plugins (#195) ⚠️
* Create versioned doc sites (#199)

⚠️: Breaking changes


### Breaking Changes
sbt-devoops no longer supports sbt 0.13 so please use sbt 1.0+
* **Drop sbt `0.13.x` support** (#141) ⚠️

***
**WARNING!!!**

All `sbt-devoops` settings and tasks now have `devOops` prefix.
* Add `devOops` prefix to avoid any potential naming conflicts with other plugins (#195) ⚠️

***

`gitHubRelease` and `gitTagAndGitHubRelease` which are now `devOopsGitHubRelease` and `devOopsGitTagAndGitHubRelease` 
do  not upload artifacts anymore. These create GitHub releases without any artifacts. 
These do upload the changelog though. To upload artifacts, please use `devOopsGitHubReleaseUploadArtifacts` task.
* Support release to upload only artifacts (#125) ⚠️
* GitHub release tasks should create a release without uploading artifacts (#163) ⚠️

***
The default branch used to tag changed from `master` to `main` so if you want to use `master`, 
please set the value of `devOopsGitTagFrom` which was `gitTagFrom` in the older version like `1.0.3`.
* Change the default branch for `devOopsGitTagFrom` from `mater` to `main` (#167) ⚠️

***

`DevOopsGitReleasePlugin` => `DevOopsGitHubReleasePlugin` and the `kevinlee.sbt.devoops` package is now just `devoops`.
* re-package from `kevinlee.sbt.devoops` to `devoops` (#173) ⚠️
* Change `DevOopsGitReleasePlugin` to `DevOopsGitHubReleasePlugin` (#187) ⚠️
* Add `@deprecated` `Plugin`s as a guide to use the new ones (#191) ⚠️
