### PR TITLE
sbt-devoops v2.1.0

### DIFF
--- a/changelogs/2.1.0.md
+++ b/changelogs/2.1.0.md
@@ -1,0 +1,9 @@
+## [2.1.0](https://github.com/Kevin-Lee/sbt-devoops/issues?utf8=✓&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone9+-label%3Adeclined) - 2021-03-18
+
+### Fixed
+* Remove invalid scalacOptions for Scala `2.11` (#208)
+
+### Done
+* Add Scala 3 `scalacOptions` (#210)
+* Set no additional `scalacOptions` for unknown `scalaVersion` (#212)
+* Add `noPublish` and `noDoc` settings to `DevOopsScalaPlugin` (#214)

--- a/project/ProjectInfo.scala
+++ b/project/ProjectInfo.scala
@@ -6,7 +6,7 @@ import wartremover.{Wart, Warts}
   */
 object ProjectInfo {
 
-  val ProjectVersion: String = "2.0.0"
+  val ProjectVersion: String = "2.1.0"
 
   val commonScalacOptions: Seq[String] = Seq(
       "-deprecation"


### PR DESCRIPTION
# sbt-devoops v2.1.0
## [2.1.0](https://github.com/Kevin-Lee/sbt-devoops/issues?utf8=✓&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone9+-label%3Adeclined) - 2021-03-18

### Fixed
* Remove invalid scalacOptions for Scala `2.11` (#208)

### Done
* Add Scala 3 `scalacOptions` (#210)
* Set no additional `scalacOptions` for unknown `scalaVersion` (#212)
* Add `noPublish` and `noDoc` settings to `DevOopsScalaPlugin` (#214)
