### PR TITLE
Close #101 - Use sbt-devoops itself to release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,9 @@ jobs:
           BINTRAY_USER: ${{ secrets.BINTRAY_USER }}
           BINTRAY_PASS: ${{ secrets.BINTRAY_PASS }}
         run: |
+          echo "====================="
+          echo "| Publish: Start    |"
+          echo "====================="
           echo "Run] sbt publish for Scala ${{ matrix.scala.version }}"
           export SOURCE_DATE_EPOCH=$(date +%s)
           echo "SOURCE_DATE_EPOCH=$SOURCE_DATE_EPOCH"
@@ -48,5 +51,9 @@ jobs:
             ^^${{ matrix.scala.sbt-version }} \
             -v \
             clean \
-            publish
+            publish \
+            devOopsGitHubRelease
+
+          echo "====================="
+          echo "| Publish: Done     |"
           echo "====================="

--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ import ProjectInfo._
 import sbt.ScmInfo
 
 lazy val root = (project in file("."))
-  .enablePlugins(DocusaurPlugin)
+  .enablePlugins(DevOopsGitHubReleasePlugin, DocusaurPlugin)
   .settings(
     organization := "io.kevinlee"
   , name         := props.ProjectName

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -11,3 +11,5 @@ addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.2.7")
 addSbtPlugin("org.lyranthe.sbt" % "partial-unification" % "1.1.2")
 
 addSbtPlugin("io.kevinlee" % "sbt-docusaur" % "0.3.0")
+
+addSbtPlugin("io.kevinlee" % "sbt-devoops" % "2.1.0")


### PR DESCRIPTION
# Summary
Close #101 - Use `sbt-devoops` itself to release