### PR TITLE
Close #222 - Add a way to detect the root project (i.e. isRootProject)

### DIFF
--- a/project/BuildTools.scala
+++ b/project/BuildTools.scala
@@ -23,8 +23,8 @@ object BuildTools {
     libraryDependencies +=
       sbtPluginExtra(
         m = organization %% name % versionSpecific(CrossVersion.partialVersion(scalaVersion.value)),
-        sbtV = (sbtBinaryVersion in pluginCrossBuild).value,
-        scalaV = (scalaBinaryVersion in update).value
+        sbtV = (pluginCrossBuild / sbtBinaryVersion).value,
+        scalaV = (update / scalaBinaryVersion).value
       )
 
   sealed trait Prefix {

--- a/src/main/scala/devoops/DevOopsSbtExtraPlugin.scala
+++ b/src/main/scala/devoops/DevOopsSbtExtraPlugin.scala
@@ -1,0 +1,48 @@
+package devoops
+
+import sbt.{Def, _}
+import cats.Eq
+import cats.syntax.eq.catsSyntaxEq
+
+/** @author Kevin Lee
+  * @since 2021-04-10
+  */
+object DevOopsSbtExtraPlugin extends AutoPlugin {
+
+  override def requires: Plugins      = empty
+  override def trigger: PluginTrigger = allRequirements
+
+  object autoImport {
+    implicit val projectRefEq: Eq[ProjectRef] = Eq.fromUniversalEquals[ProjectRef]
+
+    val rootProjectRef: Def.Initialize[ProjectRef] = Def.setting {
+      val rootBuildUri  = Keys.loadedBuild.value.root
+      val rootProjectId = Keys.loadedBuild.value.units(rootBuildUri).root
+      ProjectRef(rootBuildUri, rootProjectId)
+    }
+
+    val currentProjectRef: Def.Initialize[Task[ProjectRef]] = Def.task(Project.current(Keys.state.value))
+
+    val isRootProject: SettingKey[Boolean] = settingKey[Boolean]("Check if this project is the root project.")
+
+    val isCurrentProject: TaskKey[Boolean] = taskKey[Boolean](
+      "Check if this project is currently selected project."
+    )
+
+    val isCurrentProjectRoot: TaskKey[Boolean] = taskKey[Boolean](
+      "Check if this project is the root project as well as currently selected."
+    )
+
+    val commonSettings: SettingsDefinition = Def.settings(
+      isRootProject := Keys.thisProjectRef.value === rootProjectRef.value,
+      isCurrentProject := Keys.thisProjectRef.value === currentProjectRef.value,
+      isCurrentProjectRoot := isCurrentProject.value && isRootProject.value,
+    )
+
+  }
+
+  import autoImport._
+
+  override def projectSettings: Seq[Def.Setting[_]] = commonSettings
+
+}


### PR DESCRIPTION
# Summary
Close #222 - Add a way to detect the root project (i.e. `isRootProject`)