### PR TITLE
sbt-devoops v2.2.0

### DIFF
--- a/changelogs/2.2.0.md
+++ b/changelogs/2.2.0.md
@@ -1,0 +1,6 @@
+## [2.2.0](https://github.com/Kevin-Lee/sbt-devoops/issues?utf8=✓&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone10+-label%3Adeclined) - 2021-04-11
+
+### Done
+* Add a way to detect the root project (#222)
+* Move `noPublish` and `noDoc` to `DevOopsSbtExtraPlugin` (#224)
+* Use `sbt-devoops` itself to release (#101)

--- a/project/ProjectInfo.scala
+++ b/project/ProjectInfo.scala
@@ -6,7 +6,7 @@ import wartremover.{Wart, Warts}
   */
 object ProjectInfo {
 
-  val ProjectVersion: String = "2.1.0"
+  val ProjectVersion: String = "2.2.0"
 
   val commonScalacOptions: Seq[String] = Seq(
       "-deprecation"


### PR DESCRIPTION
# sbt-devoops v2.2.0
## [2.2.0](https://github.com/Kevin-Lee/sbt-devoops/issues?utf8=✓&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone10+-label%3Adeclined) - 2021-04-11

### Done
* Add a way to detect the root project (#222)
* Move `noPublish` and `noDoc` to `DevOopsSbtExtraPlugin` (#224)
* Use `sbt-devoops` itself to release (#101)
