### PR TITLE
sbt-devoops v2.3.0

### DIFF
--- a/changelogs/2.3.0.md
+++ b/changelogs/2.3.0.md
@@ -1,0 +1,5 @@
+## [2.3.0](https://github.com/Kevin-Lee/sbt-devoops/issues?utf8=✓&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone11+-label%3Adeclined) - 2021-05-02
+
+### Done
+* Add compiler plugins (#229)
+* Publish directly to Maven Central (#231)


### PR DESCRIPTION
# sbt-devoops v2.3.0
## [2.3.0](https://github.com/Kevin-Lee/sbt-devoops/issues?utf8=✓&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone11+-label%3Adeclined) - 2021-05-02

### Done
* Add compiler plugins (#229)
* Publish directly to Maven Central (#231)
