### PR TITLE
Close #241 - Add scalacOptions for Scala 2.13.6 and upgrade compilerPlugins

### DIFF
--- a/src/main/scala/devoops/DevOopsScalaPlugin.scala
+++ b/src/main/scala/devoops/DevOopsScalaPlugin.scala
@@ -276,7 +276,8 @@ object DevOopsScalaPlugin extends AutoPlugin {
       } else {
         val semVer = SemVer.parseUnsafe(scalaV)
         ((semVer.major, semVer.minor, semVer.patch) match {
-          case (SemVer.Major(2), SemVer.Minor(13), SemVer.Patch(5)) |
+          case (SemVer.Major(2), SemVer.Minor(13), SemVer.Patch(6)) |
+               (SemVer.Major(2), SemVer.Minor(13), SemVer.Patch(5)) |
                (SemVer.Major(2), SemVer.Minor(13), SemVer.Patch(4)) |
                (SemVer.Major(2), SemVer.Minor(13), SemVer.Patch(3)) |
                (SemVer.Major(2), SemVer.Minor(13), SemVer.Patch(2)) |
@@ -287,10 +288,14 @@ object DevOopsScalaPlugin extends AutoPlugin {
                (SemVer.Major(2), SemVer.Minor(12), SemVer.Patch(11)) |
                (SemVer.Major(2), SemVer.Minor(12), SemVer.Patch(10)) |
                (SemVer.Major(2), SemVer.Minor(12), SemVer.Patch(9)) |
-               (SemVer.Major(2), SemVer.Minor(11), SemVer.Patch(12)) |
-               (SemVer.Major(2), SemVer.Minor(10), SemVer.Patch(7)) =>
+               (SemVer.Major(2), SemVer.Minor(12), SemVer.Patch(8)) |
+               (SemVer.Major(2), SemVer.Minor(11), SemVer.Patch(12)) =>
             List(
-              compilerPlugin("org.typelevel" % "kind-projector" % "0.11.3" cross CrossVersion.full),
+              compilerPlugin("org.typelevel" % "kind-projector" % "0.13.0" cross CrossVersion.full),
+            )
+          case (SemVer.Major(2), SemVer.Minor(10), SemVer.Patch(7)) =>
+            List(
+              compilerPlugin("org.typelevel" % "kind-projector" % "0.12.0" cross CrossVersion.full),
             )
           case (SemVer.Major(2), SemVer.Minor(13), _) |
                (SemVer.Major(2), SemVer.Minor(12), _) |


### PR DESCRIPTION
# Summary
Close #241 - Add `scalacOptions` for Scala 2.13.6 and upgrade `compilerPlugin`s