### PR TITLE
sbt-devoops v2.4.0

### DIFF
--- a/changelogs/2.4.0.md
+++ b/changelogs/2.4.0.md
@@ -1,0 +1,15 @@
+## [2.4.0](https://github.com/Kevin-Lee/sbt-devoops/issues?utf8=✓&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone12+-label%3Adeclined) - 2021-05-25
+
+### Done
+* Make `strictEquality` non-default option in Scala 3 (#235)
+  * Set `useAggressiveScalacOptions` to `true` to enable `strictEquality` in Scala 3.
+* Add jar from sub-projects to `devOopsPackagedArtifacts` in `DevOopsGitHubReleasePlugin` (#236)
+  * `s"target/scala-*/${devOopsArtifactNamePrefix.value}*.jar"`
+  * `s"*/target/scala-*/${devOopsArtifactNamePrefix.value}*.jar"`
+  * `s"*/*/target/scala-*/${devOopsArtifactNamePrefix.value}*.jar"`
+* Add more `-language` `scalacOptions` for Scala 2 (#240)
+  * `"-language:existentials"         // Existential types (besides wildcard types) can be written and inferred`
+  * `"-language:experimental.macros"  // Allow macro definition (besides implementation and application)`
+  * `"-language:implicitConversions"  // Allow definition of implicit functions called views`
+* Add `scalacOptions` for Scala `2.13.6` and upgrade `compilerPlugin`s (#241)
+  * Upgraded: `kind-projector` `0.11.3` => `0.13.0`


### PR DESCRIPTION
# sbt-devoops v2.4.0
## [2.4.0](https://github.com/Kevin-Lee/sbt-devoops/issues?utf8=✓&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone12+-label%3Adeclined) - 2021-05-25

### Done
* Make `strictEquality` non-default option in Scala 3 (#235)
  * Set `useAggressiveScalacOptions` to `true` to enable `strictEquality` in Scala 3.
* Add jar from sub-projects to `devOopsPackagedArtifacts` in `DevOopsGitHubReleasePlugin` (#236)
  * `s"target/scala-*/${devOopsArtifactNamePrefix.value}*.jar"`
  * `s"*/target/scala-*/${devOopsArtifactNamePrefix.value}*.jar"`
  * `s"*/*/target/scala-*/${devOopsArtifactNamePrefix.value}*.jar"`
* Add more `-language` `scalacOptions` for Scala 2 (#240)
  * `"-language:existentials"         // Existential types (besides wildcard types) can be written and inferred`
  * `"-language:experimental.macros"  // Allow macro definition (besides implementation and application)`
  * `"-language:implicitConversions"  // Allow definition of implicit functions called views`
* Add `scalacOptions` for Scala `2.13.6` and upgrade `compilerPlugin`s (#241)
  * Upgraded: `kind-projector` `0.11.3` => `0.13.0`
