### PR TITLE
Fix #245 - strictEquality should not be default in scalacOptions in Scala 3

### DIFF
--- a/src/main/scala/devoops/DevOopsScalaPlugin.scala
+++ b/src/main/scala/devoops/DevOopsScalaPlugin.scala
@@ -40,7 +40,6 @@ object DevOopsScalaPlugin extends AutoPlugin {
         "reflectiveCalls",
         "experimental.macros",
         "implicitConversions",
-        "strictEquality",
       ).mkString(",")
 
     lazy private val aggressiveScala3cLanguageOptions =


### PR DESCRIPTION
# Summary
Fix #245 - `strictEquality` should not be default in `scalacOptions` in Scala 3