### PR TITLE
sbt-devoops v2.4.1

### DIFF
--- a/changelogs/2.4.1.md
+++ b/changelogs/2.4.1.md
@@ -1,0 +1,4 @@
+## [2.4.1](https://github.com/Kevin-Lee/sbt-devoops/issues?utf8=✓&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone13+-label%3Adeclined) - 2021-05-25
+
+### Fixed
+* `strictEquality` should not be default in `scalacOptions` in Scala 3 (#245)


### PR DESCRIPTION
# sbt-devoops v2.4.1
## [2.4.1](https://github.com/Kevin-Lee/sbt-devoops/issues?utf8=✓&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone13+-label%3Adeclined) - 2021-05-25

### Fixed
* `strictEquality` should not be default in `scalacOptions` in Scala 3 (#245)
