### PR TITLE
Close #250 - Remove -Ywarn-unused from Scala 2.11

### DIFF
--- a/src/main/scala/devoops/DevOopsScalaPlugin.scala
+++ b/src/main/scala/devoops/DevOopsScalaPlugin.scala
@@ -173,7 +173,6 @@ object DevOopsScalaPlugin extends AutoPlugin {
     , "-Xlint:_"
     , "-Ywarn-infer-any"                  // Warn when a type argument is inferred to be `Any`.
     , "-Ywarn-nullary-unit"               // Warn when nullary methods return Unit.
-    , "-Ywarn-unused"
     , "-Ywarn-unused-import"
     , "-Ypartial-unification"
     )


### PR DESCRIPTION
# Summary
Close #250 - Remove `-Ywarn-unused` from Scala 2.11