### PR TITLE
sbt-devoops v2.5.0

### DIFF
--- a/changelogs/2.5.0.md
+++ b/changelogs/2.5.0.md
@@ -1,0 +1,6 @@
+## [2.5.0](https://github.com/Kevin-Lee/sbt-devoops/issues?utf8=✓&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone14+-label%3Adeclined) - 2021-06-01
+
+### Fixed
+* Remove `-Ywarn-unused` from Scala `2.11` (#250)
+* Add compiler plugins for Scala `2.12.14` (#252)
+* Add macro `paradise` plugin for more of older Scala versions (#254)


### PR DESCRIPTION
# sbt-devoops v2.5.0
## [2.5.0](https://github.com/Kevin-Lee/sbt-devoops/issues?utf8=✓&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone14+-label%3Adeclined) - 2021-06-01

### Fixed
* Remove `-Ywarn-unused` from Scala `2.11` (#250)
* Add compiler plugins for Scala `2.12.14` (#252)
* Add macro `paradise` plugin for more of older Scala versions (#254)
