### PR TITLE
sbt-devoops v2.6.0

### DIFF
--- a/changelogs/2.6.0.md
+++ b/changelogs/2.6.0.md
@@ -1,0 +1,10 @@
+## [2.6.0](https://github.com/Kevin-Lee/sbt-devoops/issues?utf8=✓&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone15+-label%3Adeclined) - 2021-06-19
+
+### Done
+* Split `sbt-devoops` into multiple sub-projects (#258)
+* Make `sbt-devoops` to add all `sbt-devoops-*` plugins (#262)
+  * `sbt-devoops-common`
+  * `sbt-devoops-scala`
+  * `sbt-devoops-sbt-extra`
+  * `sbt-devoops-github`
+  * `sbt-devoops-java`


### PR DESCRIPTION
# sbt-devoops v2.6.0
## [2.6.0](https://github.com/Kevin-Lee/sbt-devoops/issues?utf8=✓&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone15+-label%3Adeclined) - 2021-06-19

### Done
* Split `sbt-devoops` into multiple sub-projects (#258)
* Make `sbt-devoops` to add all `sbt-devoops-*` plugins (#262)
  * `sbt-devoops-common`
  * `sbt-devoops-scala`
  * `sbt-devoops-sbt-extra`
  * `sbt-devoops-github`
  * `sbt-devoops-java`
