### PR TITLE
Close #271 - Add -source:future to scalacOptions for Scala 3

### DIFF
--- a/sbt-devoops-scala/src/main/scala/devoops/DevOopsScalaPlugin.scala
+++ b/sbt-devoops-scala/src/main/scala/devoops/DevOopsScalaPlugin.scala
@@ -51,6 +51,7 @@ object DevOopsScalaPlugin extends AutoPlugin {
       "-feature",
       "-Xfatal-warnings",
       "-explain",
+      "-source:future",
     )
     val scala3Options: Seq[String] = scala3OptionsEssential ++
       Seq(


### PR DESCRIPTION
# Summary
Close #271 - Add `-source:future` to `scalacOptions` for Scala 3