### PR TITLE
sbt-devoops v2.7.0

### DIFF
--- a/changelogs/2.7.0.md
+++ b/changelogs/2.7.0.md
@@ -1,0 +1,4 @@
+## [2.7.0](https://github.com/Kevin-Lee/sbt-devoops/issues?utf8=✓&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone16+-label%3Adeclined) - 2021-09-08
+
+### Done
+* Add `-source:future` to `scalacOptions` for Scala 3 (#271)


### PR DESCRIPTION
# sbt-devoops v2.7.0
## [2.7.0](https://github.com/Kevin-Lee/sbt-devoops/issues?utf8=✓&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone16+-label%3Adeclined) - 2021-09-08

### Done
* Add `-source:future` to `scalacOptions` for Scala 3 (#271)
