### PR TITLE
sbt-devoops v2.8.0

### DIFF
--- a/changelogs/2.8.0.md
+++ b/changelogs/2.8.0.md
@@ -1,0 +1,4 @@
+## [2.8.0](https://github.com/Kevin-Lee/sbt-devoops/issues?utf8=✓&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone17+-label%3Adeclined) - 2021-09-17
+
+### Done
+* `DevOopsScalaPlugin` should support Scala `2.12.15` (#275)


### PR DESCRIPTION
## [2.8.0](https://github.com/Kevin-Lee/sbt-devoops/issues?utf8=✓&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone17+-label%3Adeclined) - 2021-09-17

### Done
* `DevOopsScalaPlugin` should support Scala `2.12.15` (#275)
