### PR TITLE
sbt-devoops v2.9.0

### DIFF
--- a/changelogs/2.9.0.md
+++ b/changelogs/2.9.0.md
@@ -1,0 +1,4 @@
+## [2.9.0](https://github.com/Kevin-Lee/sbt-devoops/issues?utf8=✓&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone18+-label%3Adeclined) - 2021-09-17
+
+### Done
+* Make `-source:future` for Scala 3 optional (#278)


### PR DESCRIPTION
# sbt-devoops v2.9.0
## [2.9.0](https://github.com/Kevin-Lee/sbt-devoops/issues?utf8=✓&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone18+-label%3Adeclined) - 2021-09-17

### Done
* Make `-source:future` for Scala 3 optional (#278)
