### PR TITLE
sbt-devoops v2.10.0

### DIFF
--- a/changelogs/2.10.0.md
+++ b/changelogs/2.10.0.md
@@ -1,0 +1,5 @@
+## [2.10.0](https://github.com/Kevin-Lee/sbt-devoops/issues?utf8=✓&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone19+-label%3Adeclined) - 2021-09-19
+
+### Done
+* Add a task to figure out GitHub org (username) and repo name (#283) - In `sbt-devoops-github`, `gitHubFindRepoOrgAndName` task
+* Add a method to figure out GitHub org (username) and repo name #286 - In `sbt-devoops-github`, `findRepoOrgAndName` and `findRepoOrgAndNameWithLog(DevOopsLogLevel)` methods


### PR DESCRIPTION
# sbt-devoops v2.10.0
## [2.10.0](https://github.com/Kevin-Lee/sbt-devoops/issues?utf8=✓&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone19+-label%3Adeclined) - 2021-09-19

### Done
* Add a task to figure out GitHub org (username) and repo name (#283) - In `sbt-devoops-github`, `gitHubFindRepoOrgAndName` task
* Add a method to figure out GitHub org (username) and repo name #286 - In `sbt-devoops-github`, `findRepoOrgAndName` and `findRepoOrgAndNameWithLog(DevOopsLogLevel)` methods
