### PR TITLE
sbt-devoops v2.11.0

### DIFF
--- a/changelogs/2.11.0.md
+++ b/changelogs/2.11.0.md
@@ -1,0 +1,4 @@
+## [2.11.0](https://github.com/Kevin-Lee/sbt-devoops/issues?utf8=✓&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone20+-label%3Adeclined) - 2021-09-30
+
+### Done
+* Upgrade `just-sysprocess` to `1.0.0` (#293)


### PR DESCRIPTION
# sbt-devoops v2.11.0
## [2.11.0](https://github.com/Kevin-Lee/sbt-devoops/issues?utf8=✓&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone20+-label%3Adeclined) - 2021-09-30

### Done
* Upgrade `just-sysprocess` to `1.0.0` (#293)
