### PR TITLE
sbt-devoops v2.12.0

### DIFF
--- a/changelogs/2.12.0.md
+++ b/changelogs/2.12.0.md
@@ -1,0 +1,4 @@
+## [2.12.0](https://github.com/Kevin-Lee/sbt-devoops/issues?utf8=✓&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone21+-label%3Adeclined) - 2021-10-20
+
+### Done
+* Support Scala `3.1` (#296)


### PR DESCRIPTION
# sbt-devoops v2.12.0
## [2.12.0](https://github.com/Kevin-Lee/sbt-devoops/issues?utf8=✓&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone21+-label%3Adeclined) - 2021-10-20

### Done
* Support Scala `3.1` (#296)
