### PR TITLE
sbt-devoops v2.13.0

### DIFF
--- a/changelogs/2.13.0.md
+++ b/changelogs/2.13.0.md
@@ -1,0 +1,4 @@
+## [2.13.0](https://github.com/Kevin-Lee/sbt-devoops/issues?utf8=✓&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone22+-label%3Adeclined) - 2021-10-21
+
+### Done
+* Set `scalacOptions` properly for Scala `3.1` (#299)


### PR DESCRIPTION
# sbt-devoops v2.13.0
## [2.13.0](https://github.com/Kevin-Lee/sbt-devoops/issues?utf8=✓&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone22+-label%3Adeclined) - 2021-10-21

### Done
* Set `scalacOptions` properly for Scala `3.1` (#299)
