### PR TITLE
sbt-devoops v2.14.0

### DIFF
--- a/changelogs/2.14.0.md
+++ b/changelogs/2.14.0.md
@@ -1,0 +1,4 @@
+## [2.14.0](https://github.com/Kevin-Lee/sbt-devoops/issues?utf8=✓&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone23+-label%3Adeclined) - 2021-11-05
+
+### Done
+* Support `kind-projector` for Scala `2.13.7` (#302)


### PR DESCRIPTION
# sbt-devoops v2.14.0
## [2.14.0](https://github.com/Kevin-Lee/sbt-devoops/issues?utf8=✓&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone23+-label%3Adeclined) - 2021-11-05

### Done
* Support `kind-projector` for Scala `2.13.7` (#302)
