### PR TITLE
sbt-devoops v2.15.0

### DIFF
--- a/changelogs/2.15.0.md
+++ b/changelogs/2.15.0.md
@@ -1,0 +1,5 @@
+## [2.15.0](https://github.com/Kevin-Lee/sbt-devoops/issues?utf8=✓&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone24+-label%3Adeclined) - 2022-01-14
+
+### Done
+* Publish to `s01.oss.sonatype.org` (the new Maven central) (#308)
+* Support `kind-projector` for Scala 2.13.8 (#318)


### PR DESCRIPTION
# sbt-devoops v2.15.0
## [2.15.0](https://github.com/Kevin-Lee/sbt-devoops/issues?utf8=✓&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone24+-label%3Adeclined) - 2022-01-14

### Done
* Publish to `s01.oss.sonatype.org` (the new Maven central) (#308)
* Support `kind-projector` for Scala 2.13.8 (#318)
