### PR TITLE
sbt-devoops v2.16.0

### DIFF
--- a/changelogs/2.16.0.md
+++ b/changelogs/2.16.0.md
@@ -1,0 +1,4 @@
+## [2.16.0](https://github.com/Kevin-Lee/sbt-devoops/issues?utf8=✓&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone25+-label%3Adeclined) - 2022-03-05
+
+### Done
+* Add `errors` to `FailedResponseBodyJson` (#328)


### PR DESCRIPTION
# sbt-devoops v2.16.0
## [2.16.0](https://github.com/Kevin-Lee/sbt-devoops/issues?utf8=✓&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone25+-label%3Adeclined) - 2022-03-05

### Done
* Add `errors` to `FailedResponseBodyJson` (#328)
