### PR TITLE
Close #348 - Add a plugin to support sbt-release with sbt-version-policy

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -45,13 +45,13 @@ lazy val sbtDevOops = Project(props.ProjectName, file("."))
     sbtDevOopsScala,
     sbtDevOopsSbtExtra,
     sbtDevOopsGitHub,
-    sbtDevOopsJava,
   )
   .aggregate(
     sbtDevOopsCommon,
     sbtDevOopsScala,
     sbtDevOopsSbtExtra,
     sbtDevOopsGitHub,
+    sbtDevOopsReleaseVersionPolicy,
     sbtDevOopsJava,
   )
 
@@ -77,6 +77,14 @@ lazy val sbtDevOopsGitHub = subProject(props.SubProjectNameGitHub)
   .enablePlugins(SbtPlugin)
   .settings(
     libraryDependencies ++= libs.all(scalaVersion.value),
+  )
+  .dependsOn(sbtDevOopsCommon)
+
+lazy val sbtDevOopsReleaseVersionPolicy = subProject(props.SubProjectNameReleaseVersionPolicy)
+  .enablePlugins(SbtPlugin)
+  .settings(
+    addSbtPlugin(libs.sbtRelease),
+    addSbtPlugin(libs.sbtVersionPolicy),
   )
   .dependsOn(sbtDevOopsCommon)
 
@@ -113,10 +121,11 @@ def subProject(projectName: String): Project = {
         case _ =>
           true
       }),
-      scriptedLaunchOpts := { scriptedLaunchOpts.value ++
-        Seq("-Xmx1024M", "-Dplugin.version=" + version.value)
+      scriptedLaunchOpts                := {
+        scriptedLaunchOpts.value ++
+          Seq("-Xmx1024M", "-Dplugin.version=" + version.value)
       },
-      scriptedBufferLog := false,
+      scriptedBufferLog                 := false,
     )
     .settings(mavenCentralPublishSettings)
 }
@@ -135,11 +144,12 @@ lazy val props =
     val SonatypeCredentialHost = "s01.oss.sonatype.org"
     val SonatypeRepository     = s"https://$SonatypeCredentialHost/service/local"
 
-    final val SubProjectNameCommon   = "common"
-    final val SubProjectNameScala    = "scala"
-    final val SubProjectNameSbtExtra = "sbt-extra"
-    final val SubProjectNameGitHub   = "github"
-    final val SubProjectNameJava     = "java"
+    final val SubProjectNameCommon               = "common"
+    final val SubProjectNameScala                = "scala"
+    final val SubProjectNameSbtExtra             = "sbt-extra"
+    final val SubProjectNameGitHub               = "github"
+    final val SubProjectNameReleaseVersionPolicy = "release-version-policy"
+    final val SubProjectNameJava                 = "java"
 
     final val ProjectScalaVersion = "2.12.12"
     final val CrossScalaVersions  = List(ProjectScalaVersion).distinct
@@ -174,6 +184,9 @@ lazy val props =
 
     final val activationVersion    = "1.1.1"
     final val activationApiVersion = "1.2.0"
+
+    val SbtVersionPolicyVersion = "2.0.1"
+    val SbtReleaseVersion       = "1.1.0"
 
     final val IncludeTest = "compile->compile;test->test"
   }
@@ -227,6 +240,9 @@ lazy val libs =
     lazy val javaxActivation212 = List(
       "javax.activation" % "activation" % props.activationVersion,
     )
+
+    lazy val sbtVersionPolicy = "ch.epfl.scala"  % "sbt-version-policy" % props.SbtVersionPolicyVersion
+    lazy val sbtRelease       = "com.github.sbt" % "sbt-release"        % props.SbtReleaseVersion
 
     def all(scalaVersion: String) = crossVersionProps(
       List(

--- a/modules/sbt-devoops-common/src/main/scala/kevinlee/sbt/SbtCommon.scala
+++ b/modules/sbt-devoops-common/src/main/scala/kevinlee/sbt/SbtCommon.scala
@@ -16,4 +16,7 @@ object SbtCommon {
   @SuppressWarnings(Array("org.wartremover.warts.Throw"))
   def messageOnlyException(message: String): Nothing =
     throw new MessageOnlyException(message)
+
+  def assertOrMessageOnlyException(assertion: Boolean, message: => String): Unit =
+    if (assertion) () else messageOnlyException(message)
 }

--- a/modules/sbt-devoops-release-version-policy/src/main/scala/devoops/DevOopsReleaseVersionPolicy.scala
+++ b/modules/sbt-devoops-release-version-policy/src/main/scala/devoops/DevOopsReleaseVersionPolicy.scala
@@ -1,0 +1,146 @@
+package devoops
+
+import kevinlee.sbt.SbtCommon._
+import sbt.Keys._
+import sbt._
+import sbtrelease.ReleasePlugin
+import sbtrelease.ReleasePlugin.autoImport._
+import sbtversionpolicy.SbtVersionPolicyPlugin
+import sbtversionpolicy.SbtVersionPolicyPlugin.autoImport._
+
+/** @author Kevin Lee
+  * @since 2022-05-01
+  */
+object DevOopsReleaseVersionPolicy extends AutoPlugin {
+  override def requires: Plugins      = SbtVersionPolicyPlugin && ReleasePlugin
+  override def trigger: PluginTrigger = noTrigger
+
+  object autoImport {
+    val CompatibilityFilename: String                             = "compatibility.sbt"
+    val CompatibilityFileContent: String                          =
+      "ThisBuild / versionPolicyIntention := Compatibility.BinaryAndSourceCompatible\n"
+    val CompatibilityFileAdditionalContentForFirstRelease: String =
+      """// If this project has never been released, use the following one instead and remove the one above.
+        |// ThisBuild / versionPolicyIntention := Compatibility.None
+        |""".stripMargin
+
+    val DefaultCompatibilityResetGitCommitMessage: String = "Reset compatibility intention"
+
+    lazy val compatibilityResetGitCommitMessage: SettingKey[String] = settingKey[String](
+      s"A message used to commit the compatibility intention reset. (default: $DefaultCompatibilityResetGitCommitMessage)"
+    )
+
+    lazy val setAndCommitNextCompatibilityIntention: TaskKey[Unit] =
+      taskKey[Unit]("Set versionPolicyIntention to Compatibility.BinaryAndSourceCompatible, and commit the change")
+
+    lazy val initVersionPolicy: TaskKey[Unit] = taskKey(s"Create the initial $CompatibilityFilename file")
+  }
+
+  import autoImport._
+
+  ThisBuild / initVersionPolicy                  := {
+    val log               = streams.value.log
+    val compatibilityFile = new File(CompatibilityFilename)
+    if (compatibilityFile.exists) {
+      log.warn(
+        s"Failed to create $CompatibilityFilename. $CompatibilityFilename file already exists so you should use the existing file."
+      )
+    } else {
+      log.info(s"Create $CompatibilityFilename and set compatibility intention to BinaryAndSourceCompatible")
+      IO.write(
+        compatibilityFile,
+        CompatibilityFileContent + CompatibilityFileAdditionalContentForFirstRelease,
+      )
+    }
+  }
+
+  ThisBuild / compatibilityResetGitCommitMessage := DefaultCompatibilityResetGitCommitMessage
+
+  ThisBuild / setAndCommitNextCompatibilityIntention := {
+    val log           = streams.value.log
+    val intention     = (ThisBuild / versionPolicyIntention).value
+    val commitMessage = (ThisBuild / compatibilityResetGitCommitMessage).value
+    intention match {
+      case Compatibility.BinaryAndSourceCompatible =>
+        log.info("Not changing compatibility intention because it is already set to BinaryAndSourceCompatible")
+
+      case Compatibility.BinaryCompatible | Compatibility.None =>
+        log.info("Reset compatibility intention to BinaryAndSourceCompatible")
+        IO.write(
+          new File(CompatibilityFilename),
+          CompatibilityFileContent,
+        )
+        val gitAddExitValue = sys
+          .process
+          .Process(s"git add $CompatibilityFilename")
+          .run(log)
+          .exitValue()
+        @SuppressWarnings(Array("org.wartremover.warts.Equals"))
+        val gitAddSuccess   = gitAddExitValue == 0
+        assertOrMessageOnlyException(gitAddSuccess, s"Command failed with exit status $gitAddExitValue")
+
+        val gitCommitExitValue =
+          sys
+            .process
+            .Process(
+              List(
+                "git",
+                "commit",
+                "-m",
+                commitMessage,
+              )
+            )
+            .run(log)
+            .exitValue()
+        @SuppressWarnings(Array("org.wartremover.warts.Equals"))
+        val gitCommitSuccess   = gitCommitExitValue == 0
+        assertOrMessageOnlyException(gitCommitSuccess, s"Command failed with exit status $gitCommitExitValue")
+    }
+  }
+
+  override lazy val projectSettings: Seq[Setting[_]] = Seq(
+    releaseVersion := {
+      val maybeBump: Option[sbtrelease.Version.Bump] = versionPolicyIntention.value match {
+        case Compatibility.None => Some(sbtrelease.Version.Bump.Major)
+        case Compatibility.BinaryCompatible => Some(sbtrelease.Version.Bump.Minor)
+        /* No need to bump the patch version, because it has already been bumped when sbt-release set the next release version */
+        case Compatibility.BinaryAndSourceCompatible => None
+      }
+
+      { (currentVersion: String) =>
+        val versionWithoutQualifier =
+          sbtrelease
+            .Version(currentVersion)
+            .getOrElse(sbtrelease.versionFormatError(currentVersion))
+            .withoutQualifier
+        (maybeBump match {
+          case Some(bump) => versionWithoutQualifier.bump(bump)
+          case None => versionWithoutQualifier
+        }).string
+      }
+    },
+    /* Custom release process: run `versionCheck` after we have set the release version, and
+     * reset compatibility intention to `Compatibility.BinaryAndSourceCompatible` after the release.
+     */
+    releaseProcess := {
+      Seq[ReleaseStep](
+        ReleaseTransformations.checkSnapshotDependencies,
+        ReleaseTransformations.inquireVersions,
+        ReleaseTransformations.runClean,
+        ReleaseTransformations.runTest,
+        ReleaseTransformations.setReleaseVersion,
+        releaseStepCommand("versionCheck"), // Run task `versionCheck` after the release version is set
+        ReleaseTransformations.commitReleaseVersion,
+        ReleaseTransformations.tagRelease,
+        ReleaseTransformations.publishArtifacts, // Publish locally for our tests only, in practice you will publish to Sonatype
+        ReleaseTransformations.setNextVersion,
+        ReleaseTransformations.commitNextVersion,
+        releaseStepTask(
+          /* Reset compatibility intention to `Compatibility.BinaryAndSourceCompatible` */
+          setAndCommitNextCompatibilityIntention
+        ),
+        ReleaseTransformations.pushChanges,
+      )
+    },
+  )
+}


### PR DESCRIPTION
# Summary
Close #348 - Add a plugin to support `sbt-release` with `sbt-version-policy`