### PR TITLE
sbt-devoops v2.17.0

### DIFF
--- a/changelogs/2.17.0.md
+++ b/changelogs/2.17.0.md
@@ -1,0 +1,9 @@
+## [2.17.0](https://github.com/Kevin-Lee/sbt-devoops/issues?utf8=✓&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone26+-label%3Adeclined) - 2022-05-03
+
+### Done
+* Update `devOopsPackagedArtifacts` to include sub-projects with Scala.js (#351)
+* Add a plugin to support `sbt-release` with `sbt-version-policy` (#348)
+* Add `sbt-test` (`scripted`) to `sbt-devoops-scala` (#344)
+* Upgrade `just-semver`, `cats` and `cats-effect` (#342)
+* Upgrade libraries - `effectie`, `logger-f`, `http4s`, `circe`, `refined`, `hedgehog` and `extras` (#340)
+* Move all sub-projects to modules (#338)


### PR DESCRIPTION
# sbt-devoops v2.17.0
## [2.17.0](https://github.com/Kevin-Lee/sbt-devoops/issues?utf8=✓&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone26+-label%3Adeclined) - 2022-05-03

### Done
* Update `devOopsPackagedArtifacts` to include sub-projects with Scala.js (#351)
* Add a plugin to support `sbt-release` with `sbt-version-policy` (#348)
* Add `sbt-test` (`scripted`) to `sbt-devoops-scala` (#344)
* Upgrade `just-semver`, `cats` and `cats-effect` (#342)
* Upgrade libraries - `effectie`, `logger-f`, `http4s`, `circe`, `refined`, `hedgehog` and `extras` (#340)
* Move all sub-projects to modules (#338)
