### PR TITLE
sbt-devoops v2.18.0

### DIFF
--- a/changelogs/2.18.0.md
+++ b/changelogs/2.18.0.md
@@ -1,0 +1,5 @@
+## [2.18.0](https://github.com/Kevin-Lee/sbt-devoops/issues?q=is%3Aissue+is%3Aclosed+-label%3Adeclined+milestone%3Amilestone27) - 2022-05-03
+
+### Done
+* Rename `DevOopsReleaseVersionPolicy` to `DevOopsReleaseVersionPolicyPlugin` (#354)
+* Change `DevOopsReleaseVersionPolicyPlugin.trigger` to `allRequirements` (#356)


### PR DESCRIPTION
# sbt-devoops v2.18.0
## [2.18.0](https://github.com/Kevin-Lee/sbt-devoops/issues?q=is%3Aissue+is%3Aclosed+-label%3Adeclined+milestone%3Amilestone27) - 2022-05-03

### Done
* Rename `DevOopsReleaseVersionPolicy` to `DevOopsReleaseVersionPolicyPlugin` (#354)
* Change `DevOopsReleaseVersionPolicyPlugin.trigger` to `allRequirements` (#356)