### PR TITLE
sbt-devoops v2.19.0

### DIFF
--- a/changelogs/2.19.0.md
+++ b/changelogs/2.19.0.md
@@ -1,0 +1,12 @@
+## [2.19.0](https://github.com/Kevin-Lee/sbt-devoops/issues?q=is%3Aissue+is%3Aclosed+-label%3Adeclined+milestone%3Amilestone28) - 2022-05-06
+
+### Done
+* Upgrade libraries (#361)
+  * cats-effect `2.5.4` => `3.3.5`
+  * refined `0.9.27` => `0.9.28`
+  * http4s `0.22.12` => `0.23.11`
+  * commons-io `2.8.0` => `2.11.0`
+  * Add `extras-hedgehog-cats-effect3` `0.13.0` for testing
+* Set all `task`s and `setting`s in `DevOopsReleaseVersionPolicyPlugin` properly (#359)
+  * Move all `setting`s and `task`s in `ThisBuild` to `buildSettings`
+  * Make sure there is the right instruction to set up `versionPolicyIntention` and it's displayed when `versionPolicyIntention` is not set.


### PR DESCRIPTION
# sbt-devoops v2.19.0
## [2.19.0](https://github.com/Kevin-Lee/sbt-devoops/issues?q=is%3Aissue+is%3Aclosed+-label%3Adeclined+milestone%3Amilestone28) - 2022-05-06

### Done
* Upgrade libraries (#361)
  * cats-effect `2.5.4` => `3.3.5`
  * refined `0.9.27` => `0.9.28`
  * http4s `0.22.12` => `0.23.11`
  * commons-io `2.8.0` => `2.11.0`
  * Add `extras-hedgehog-cats-effect3` `0.13.0` for testing
* Set all `task`s and `setting`s in `DevOopsReleaseVersionPolicyPlugin` properly (#359)
  * Move all `setting`s and `task`s in `ThisBuild` to `buildSettings`
  * Make sure there is the right instruction to set up `versionPolicyIntention` and it's displayed when `versionPolicyIntention` is not set.