### PR TITLE
sbt-devoops v2.20.0

### DIFF
--- a/changelogs/2.20.0.md
+++ b/changelogs/2.20.0.md
@@ -1,0 +1,4 @@
+## [2.20.0](https://github.com/Kevin-Lee/sbt-devoops/issues?q=is%3Aissue+is%3Aclosed+-label%3Adeclined+milestone%3Amilestone29) - 2022-05-17
+
+### Done
+* [sbt-devoops-release-version-policy] Add better instruction for missing compatibility file (#364)


### PR DESCRIPTION
# sbt-devoops v2.20.0
## [2.20.0](https://github.com/Kevin-Lee/sbt-devoops/issues?q=is%3Aissue+is%3Aclosed+-label%3Adeclined+milestone%3Amilestone29) - 2022-05-17

### Done
* [sbt-devoops-release-version-policy] Add better instruction for missing compatibility file (#364)
