### PR TITLE
Close #368 - Add `DevOopsStarterPlugin` plugin

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -50,6 +50,7 @@ lazy val sbtDevOops = Project(props.ProjectName, file("."))
     sbtDevOopsCommon,
     sbtDevOopsScala,
     sbtDevOopsSbtExtra,
+    sbtDevOopsStarter,
     sbtDevOopsGitHub,
     sbtDevOopsReleaseVersionPolicy,
     sbtDevOopsJava,
@@ -72,6 +73,15 @@ lazy val sbtDevOopsScala = subProject(props.SubProjectNameScala)
 
 lazy val sbtDevOopsSbtExtra = subProject(props.SubProjectNameSbtExtra)
   .enablePlugins(SbtPlugin)
+
+lazy val sbtDevOopsStarter = subProject(props.SubProjectNameStarter)
+  .enablePlugins(SbtPlugin)
+  .settings(
+    addSbtPlugin(libs.sbtScalafmt),
+    addSbtPlugin(libs.sbtScalafix),
+    addSbtPlugin(libs.sbtWelcome),
+  )
+  .dependsOn(sbtDevOopsScala, sbtDevOopsSbtExtra)
 
 lazy val sbtDevOopsGitHub = subProject(props.SubProjectNameGitHub)
   .enablePlugins(SbtPlugin)
@@ -151,6 +161,7 @@ lazy val props =
     final val SubProjectNameCommon               = "common"
     final val SubProjectNameScala                = "scala"
     final val SubProjectNameSbtExtra             = "sbt-extra"
+    final val SubProjectNameStarter              = "starter"
     final val SubProjectNameGitHub               = "github"
     final val SubProjectNameReleaseVersionPolicy = "release-version-policy"
     final val SubProjectNameJava                 = "java"
@@ -191,6 +202,11 @@ lazy val props =
 
     val SbtVersionPolicyVersion = "2.0.1"
     val SbtReleaseVersion       = "1.1.0"
+
+    val SbtScalafmtVersion = "2.4.6"
+    val SbtScalafixVersion = "0.10.0"
+
+    val SbtWelcomeVersion = "0.2.2"
 
     final val IncludeTest = "compile->compile;test->test"
   }
@@ -251,6 +267,11 @@ lazy val libs =
     lazy val sbtVersionPolicy = "ch.epfl.scala"  % "sbt-version-policy" % props.SbtVersionPolicyVersion
     lazy val sbtRelease       = "com.github.sbt" % "sbt-release"        % props.SbtReleaseVersion
 
+    lazy val sbtScalafmt = "org.scalameta" % "sbt-scalafmt" % props.SbtScalafmtVersion
+    lazy val sbtScalafix = "ch.epfl.scala" % "sbt-scalafix" % props.SbtScalafixVersion
+
+    lazy val sbtWelcome = "com.github.reibitto" % "sbt-welcome" % props.SbtWelcomeVersion
+
     def all(scalaVersion: String) = crossVersionProps(
       List(
         commonsIo,
@@ -277,6 +298,7 @@ lazy val libs =
 
 lazy val writeVersion = inputKey[Unit]("Write Version in File'")
 
+import scala.{Console => sConsole}
 logo :=
   raw"""
        |       __   __      ___           ____
@@ -285,8 +307,8 @@ logo :=
        |/___/_.__/\__/   /____/\__/|___/\____/\___/ .__/___/
        |                                         /_/
        |
-       |${scala.Console.BLUE}${name.value}${scala.Console.RESET} v${scala.Console.BLUE}${version.value}${scala.Console.RESET}
-       |${scala.Console.YELLOW}Scala ${scalaVersion.value}${scala.Console.RESET}
+       |${sConsole.BLUE}${name.value}${sConsole.RESET} v${sConsole.BLUE}${version.value}${sConsole.RESET}
+       |${sConsole.YELLOW}Scala ${scalaVersion.value}${sConsole.RESET}
        |-----------------------------------------------------
        |""".stripMargin
 
@@ -303,4 +325,4 @@ usefulTasks := Seq(
   UsefulTask("pl", "publishLocal", "Run publishLocal"),
 )
 
-logoColor := scala.Console.MAGENTA
+logoColor := sConsole.MAGENTA

--- a/modules/sbt-devoops-starter/src/main/scala/devoops/DevOopsStarterPlugin.scala
+++ b/modules/sbt-devoops-starter/src/main/scala/devoops/DevOopsStarterPlugin.scala
@@ -1,0 +1,90 @@
+package devoops
+
+import org.scalafmt.sbt.ScalafmtPlugin
+import sbt.Keys.{name, scalaVersion, version}
+import sbt._
+import Def.Setting
+import sbtwelcome.WelcomePlugin
+import sbtwelcome.WelcomePlugin.autoImport.{logo, logoColor, usefulTasks}
+import scalafix.sbt.ScalafixPlugin
+
+import scala.{Console => sConsole}
+
+/** @author Kevin Lee
+  * @since 2022-05-21
+  */
+object DevOopsStarterPlugin extends AutoPlugin {
+
+  override def requires: Plugins =
+    DevOopsScalaPlugin && DevOopsSbtExtraPlugin && ScalafmtPlugin && ScalafixPlugin && WelcomePlugin
+
+  override def trigger: PluginTrigger = allRequirements
+
+  object autoImport {
+
+    val DefaultLogo: String =
+      """
+        |       __   __      ___           ____
+        |  ___ / /  / /_____/ _ \___ _  __/ __ \___  ___  ___
+        | (_-</ _ \/ __/___/ // / -_) |/ / /_/ / _ \/ _ \(_-<
+        |/___/_.__/\__/   /____/\__/|___/\____/\___/ .__/___/
+        |                                         /_/
+        |""".stripMargin
+
+    lazy val theLogo: SettingKey[String] = settingKey(
+      "The logo String used in the settingKey logo (default: The value of DefaultLogo)"
+    )
+
+    lazy val logoAdditionalInfo: SettingKey[String] = settingKey(
+      """The additional information displayed after logo (default: "")"""
+    )
+
+    def genLogo(
+      projectName: String,
+      projectVersion: String,
+      scalaVersion: String,
+      theLogo: String,
+      logoAdditionalInfo: String
+    ): String = {
+      raw"""$theLogo
+           |${sConsole.BLUE}$projectName${sConsole.RESET} ${sConsole.GREEN}$projectVersion${sConsole.RESET}
+           |${sConsole.YELLOW}Scala $scalaVersion${sConsole.RESET}
+           |-----------------------------------------------------
+           |$logoAdditionalInfo""".stripMargin
+    }
+
+  }
+
+  import autoImport._
+  import sbtwelcome._
+
+  override def projectSettings: Seq[Setting[_]] = Seq(
+    theLogo            := DefaultLogo,
+    logoAdditionalInfo := "",
+    logo               := genLogo(
+      name.value,
+      version.value,
+      scalaVersion.value,
+      theLogo.value,
+      logoAdditionalInfo.value
+    ),
+    usefulTasks        := Seq(
+      UsefulTask("r", "reload", "Run reload"),
+      UsefulTask("cln", "clean", "Run clean"),
+      UsefulTask("c", "compile", "Run compile"),
+      UsefulTask("cc", "+compile", "Run cross-scalaVersion compile"),
+      UsefulTask("tc", "Test/compile", "Run Test/compile"),
+      UsefulTask("ctc", "+Test/compile", "Run cross-scalaVersion Test/compile"),
+      UsefulTask("t", "test", "Run test"),
+      UsefulTask("ct", "+test", "Run cross-scalaVersion test"),
+      UsefulTask("fmtchk", "scalafmtCheckAll", "Run scalafmtCheckAll"),
+      UsefulTask("fmt", "scalafmtAll", "Run scalafmtAll"),
+      UsefulTask("fixchk", "scalafixAll --check", "Run scalafixAll --check"),
+      UsefulTask("fix", "scalafixAll", "Run scalafixAll"),
+      UsefulTask("chk", "fmtchk; fixchk", "Run scalafmtCheckAll; scalafixAll --check"),
+      UsefulTask("pl", "publishLocal", "Run publishLocal"),
+    ),
+    logoColor          := sConsole.MAGENTA
+  )
+
+}


### PR DESCRIPTION
# Summary
Close #368 - Add `DevOopsStarterPlugin` plugin
- `DevOopsStarterPlugin` includes `sbt-scalafmt`, `sbt-scalafix` and `sbt-welcome` plugins
