### PR TITLE
Update: Fix doc-site-build-only.yml - not to publish auto build

### DIFF
--- a/.github/workflows/doc-site-build-only.yml
+++ b/.github/workflows/doc-site-build-only.yml
@@ -60,5 +60,4 @@ jobs:
             docusaurGenerateGoogleAnalyticsConfigFile \
             docusaurInstall \
             docusaurCleanBuild \
-            docusaurBuild \
-            publishToGitHubPages
+            docusaurBuild


### PR DESCRIPTION
# Summary
Update: Fix `doc-site-build-only.yml` - not to publish auto build