### PR TITLE
sbt-devoops v2.21.0

### DIFF
--- a/changelogs/2.21.0.md
+++ b/changelogs/2.21.0.md
@@ -1,0 +1,8 @@
+## [2.21.0](https://github.com/Kevin-Lee/sbt-devoops/issues?q=is%3Aissue+is%3Aclosed+-label%3Adeclined+milestone%3Amilestone30) - 2022-06-12
+
+### Done
+* Add `DevOopsStarterPlugin` plugin (#368)
+* Move common http and GitHub related code to another core project (#370)
+* Add task to write a default `.scalafmt.conf` file (#372)
+* Add task to write default `.scalafix.conf` files (#375)
+* Replace `http4s-blaze-client` with `http4s-ember-client` (#382)


### PR DESCRIPTION
# sbt-devoops v2.21.0
## [2.21.0](https://github.com/Kevin-Lee/sbt-devoops/issues?q=is%3Aissue+is%3Aclosed+-label%3Adeclined+milestone%3Amilestone30) - 2022-06-12

### Done
* Add `DevOopsStarterPlugin` plugin (#368)
* Move common http and GitHub related code to another core project (#370)
* Add task to write a default `.scalafmt.conf` file (#372)
* Add task to write default `.scalafix.conf` files (#375)
* Replace `http4s-blaze-client` with `http4s-ember-client` (#382)
