### PR TITLE
sbt-devoops v2.23.0

### DIFF
--- a/changelogs/2.23.0.md
+++ b/changelogs/2.23.0.md
@@ -1,0 +1,4 @@
+## [2.23.0](https://github.com/Kevin-Lee/sbt-devoops/issues?q=is%3Aissue+is%3Aclosed+-label%3Adeclined+milestone%3Amilestone32) - 2022-10-03
+
+### Done
+* [`sbt-devoops-scala`]: `DevOopsScalaPlugin` - Add support for new Scala versions and bump libraries (#390)


### PR DESCRIPTION
# sbt-devoops v2.23.0
## [2.23.0](https://github.com/Kevin-Lee/sbt-devoops/issues?q=is%3Aissue+is%3Aclosed+-label%3Adeclined+milestone%3Amilestone32) - 2022-10-03

### Done
* [`sbt-devoops-scala`]: `DevOopsScalaPlugin` - Add support for new Scala versions and bump libraries (#390)
