### PR TITLE
sbt-devoops v2.24.0

### DIFF
--- a/changelogs/2.24.0.md
+++ b/changelogs/2.24.0.md
@@ -1,0 +1,14 @@
+## [2.24.0](https://github.com/Kevin-Lee/sbt-devoops/issues?q=is%3Aissue+is%3Aclosed+-label%3Adeclined+milestone%3Amilestone33) - 2022-12-27
+
+### Done
+* Upgrade `effectie` and `logger-f` to `2.0.0-beta4` (#401) - and update the code accordingly / also upgrade other libraries
+  * effectie `2.0.0-beta2` => `2.0.0-beta4`
+  * logger-f `2.0.0-beta2` => `2.0.0-beta4`
+  * sbt `1.8.0-RC1` => `1.8.0`
+  * hedgehog `0.9.0` => `0.10.1`
+  * cats `2.8.0` => `2.9.0`
+  * cats-effect `3.3.14` => `3.4.3`
+  * extras `0.20.0` => `0.26.0`
+  * just-semver `0.5.0` => `0.6.0`
+  * sbt-scalafmt `2.4.6` => `2.5.0`
+  * sbt-scalafix `0.10.3` => `0.10.4`


### PR DESCRIPTION
# sbt-devoops v2.24.0
## [2.24.0](https://github.com/Kevin-Lee/sbt-devoops/issues?q=is%3Aissue+is%3Aclosed+-label%3Adeclined+milestone%3Amilestone33) - 2022-12-27

### Done
* Upgrade `effectie` and `logger-f` to `2.0.0-beta4` (#401) - and update the code accordingly / also upgrade other libraries
  * effectie `2.0.0-beta2` => `2.0.0-beta4`
  * logger-f `2.0.0-beta2` => `2.0.0-beta4`
  * sbt `1.8.0-RC1` => `1.8.0`
  * hedgehog `0.9.0` => `0.10.1`
  * cats `2.8.0` => `2.9.0`
  * cats-effect `3.3.14` => `3.4.3`
  * extras `0.20.0` => `0.26.0`
  * just-semver `0.5.0` => `0.6.0`
  * sbt-scalafmt `2.4.6` => `2.5.0`
  * sbt-scalafix `0.10.3` => `0.10.4`
