### PR TITLE
Fix #414 - `sbt-devoops-release-version-policy` cannot handle aggregate projects with different cross Scala versions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -221,7 +221,7 @@ lazy val props =
     final val activationVersion    = "1.1.1"
     final val activationApiVersion = "1.2.0"
 
-    val SbtVersionPolicyVersion = "2.0.1"
+    val SbtVersionPolicyVersion = "2.1.3"
     val SbtReleaseVersion       = "1.1.0"
 
     val SbtScalafmtVersion = "2.5.0"


### PR DESCRIPTION
Fix #414 - `sbt-devoops-release-version-policy` cannot handle aggregate projects with different cross Scala versions

`sbt-release`, which is used by `sbt-devoops-release-version-policy`, can't handle aggregate projects with different cross Scala versions. ([Issue reproted](https://github.com/sbt/sbt-release/issues/214))

e.g.) So `sbt-release` can't handle a project structured like the following.
- root
  - module1 - Scala 2 and 3
  - module2 - Scala 2

It releases artifacts for only Scala 2.

This PR is a workaround to handle it based on https://github.com/sbt/sbt-release/issues/214#issuecomment-368407088 with a way to skip test if it's set to be skipped.
There are 
* an option to do or don't do cross Scala version release (default: do cross Scala versions) and
* an option to set a publish command (default: `publish`).
