### PR TITLE
sbt-devoops v2.24.1

### DIFF
--- a/changelogs/2.24.1.md
+++ b/changelogs/2.24.1.md
@@ -1,0 +1,19 @@
+## [2.24.1](https://github.com/kevin-lee/sbt-devoops/issues?q=is%3Aissue+is%3Aclosed+-label%3Adeclined+milestone%3Amilestone34) - 2023-11-17
+
+### Bug Fix
+* Fix: `sbt-devoops-release-version-policy` cannot handle aggregate projects with different cross Scala versions (`#414`)
+  
+  `sbt-release`, which is used by `sbt-devoops-release-version-policy`, can't handle aggregate projects with different cross Scala versions. ([Issue reproted](https://github.com/sbt/sbt-release/issues/214))
+
+  e.g.) So `sbt-release` can't handle a project structured like the following.
+  * root
+    * module1 - Scala 2 and 3
+    * module2 - Scala 2
+
+  It releases artifacts for only Scala 2.
+
+  This Release fixed it to handle it properly based on https://github.com/sbt/sbt-release/issues/214#issuecomment-368407088 with a way to skip test if it's set to be skipped.
+
+  There are
+  * an option to do or don't do cross Scala version release (default: do cross Scala versions) and
+  * an option to set a publish command (default: `publish`).


### PR DESCRIPTION
# sbt-devoops v2.24.1
## [2.24.1](https://github.com/kevin-lee/sbt-devoops/issues?q=is%3Aissue+is%3Aclosed+-label%3Adeclined+milestone%3Amilestone34) - 2023-11-17

### Bug Fix
* Fix: `sbt-devoops-release-version-policy` cannot handle aggregate projects with different cross Scala versions (`#414`)
  
  `sbt-release`, which is used by `sbt-devoops-release-version-policy`, can't handle aggregate projects with different cross Scala versions. ([Issue reproted](https://github.com/sbt/sbt-release/issues/214))

  e.g.) So `sbt-release` can't handle a project structured like the following.
  * root
    * module1 - Scala 2 and 3
    * module2 - Scala 2

  It releases artifacts for only Scala 2.

  This Release fixed it to handle it properly based on https://github.com/sbt/sbt-release/issues/214#issuecomment-368407088 with a way to skip test if it's set to be skipped.

  There are
  * an option to do or don't do cross Scala version release (default: do cross Scala versions) and
  * an option to set a publish command (default: `publish`).
