### PR TITLE
Close #418 - Upgrade Scala, sbt, sbt plugins and libraries

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -187,7 +187,7 @@ lazy val props =
     final val SubProjectNameReleaseVersionPolicy = "release-version-policy"
     final val SubProjectNameJava                 = "java"
 
-    final val ProjectScalaVersion = "2.12.17"
+    final val ProjectScalaVersion = "2.12.18"
     final val CrossScalaVersions  = List(ProjectScalaVersion).distinct
 
     final val GlobalSbtVersion = "1.3.4"
@@ -224,10 +224,10 @@ lazy val props =
     val SbtVersionPolicyVersion = "2.1.3"
     val SbtReleaseVersion       = "1.1.0"
 
-    val SbtScalafmtVersion = "2.5.0"
-    val SbtScalafixVersion = "0.10.4"
+    val SbtScalafmtVersion = "2.5.2"
+    val SbtScalafixVersion = "0.11.1"
 
-    val SbtWelcomeVersion = "0.2.2"
+    val SbtWelcomeVersion = "0.4.0"
 
     final val IncludeTest = "compile->compile;test->test"
   }
@@ -336,19 +336,22 @@ logo :=
 
 import sbtwelcome._
 
+val aliasFormatter: String => String =
+  _ + s"${scala.io.AnsiColor.RESET}: "
+
 usefulTasks := Seq(
-  UsefulTask("r", "reload", "Run reload"),
-  UsefulTask("cln", "clean", "Run clean"),
-  UsefulTask("c", "compile", "Run compile"),
-  UsefulTask("tc", "Test/compile", "Run Test/compile"),
-  UsefulTask("t", "test", "Run test"),
-  UsefulTask("st", "scripted", "Run scripted for sbt-test"),
-  UsefulTask("fmtchk", "scalafmtCheckAll", "Run scalafmtCheckAll"),
-  UsefulTask("fmt", "scalafmtAll", "Run scalafmtAll"),
-  UsefulTask("pl", "publishLocal", "Run publishLocal"),
-  UsefulTask("du", "dependencyUpdates", "Run dependencyUpdates"),
-  UsefulTask("uud", "unusedCompileDependencies", "Run unusedCompileDependencies"),
-  UsefulTask("udd", "undeclaredCompileDependencies", "Run undeclaredCompileDependencies"),
-)
+  UsefulTask("reload", "Run reload").alias("r"),
+  UsefulTask("clean", "Run clean").alias("cln"),
+  UsefulTask("compile", "Run compile").alias("c"),
+  UsefulTask("Test/compile", "Run Test/compile").alias("tc"),
+  UsefulTask("test", "Run test").alias("t"),
+  UsefulTask("scripted", "Run scripted for sbt-test").alias("st"),
+  UsefulTask("scalafmtCheckAll", "Run scalafmtCheckAll").alias("fmtchk"),
+  UsefulTask("scalafmtAll", "Run scalafmtAll").alias("fmt"),
+  UsefulTask("publishLocal", "Run publishLocal").alias("pl"),
+  UsefulTask("dependencyUpdates", "Run dependencyUpdates").alias("du"),
+  UsefulTask("unusedCompileDependencies", "Run unusedCompileDependencies").alias("uud"),
+  UsefulTask("undeclaredCompileDependencies", "Run undeclaredCompileDependencies").alias("udd"),
+).map(_.formatAlias(aliasFormatter))
 
 logoColor := sConsole.MAGENTA

--- a/modules/sbt-devoops-scala/src/sbt-test/sbt-devoops-scala/scala-2-test/build.sbt
+++ b/modules/sbt-devoops-scala/src/sbt-test/sbt-devoops-scala/scala-2-test/build.sbt
@@ -5,7 +5,7 @@ ThisBuild / organizationName := "example"
 
 ThisBuild / crossScalaVersions := List(
   "2.13.9",
-  "2.12.17",
+  "2.12.18",
 )
 
 lazy val root = (project in file("."))

--- a/modules/sbt-devoops-scala/src/sbt-test/sbt-devoops-scala/scala-2-test/project/build.properties
+++ b/modules/sbt-devoops-scala/src/sbt-test/sbt-devoops-scala/scala-2-test/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.7.2
+sbt.version=1.9.7

--- a/modules/sbt-devoops-scala/src/sbt-test/sbt-devoops-scala/scala-3-test/project/build.properties
+++ b/modules/sbt-devoops-scala/src/sbt-test/sbt-devoops-scala/scala-3-test/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.7.2
+sbt.version=1.9.7

--- a/modules/sbt-devoops-starter/src/main/scala/devoops/DevOopsStarterPlugin.scala
+++ b/modules/sbt-devoops-starter/src/main/scala/devoops/DevOopsStarterPlugin.scala
@@ -108,6 +108,9 @@ object DevOopsStarterPlugin extends AutoPlugin {
            |$logoAdditionalInfo""".stripMargin
     }
 
+    val sbtWelcomeAliasFormatter: String => String =
+      _ + s"${scala.io.AnsiColor.RESET}: "
+
   }
 
   import autoImport.*
@@ -290,26 +293,26 @@ object DevOopsStarterPlugin extends AutoPlugin {
       logoAdditionalInfo.value
     ),
     usefulTasks := Seq(
-      UsefulTask("r", "reload", "Run reload"),
-      UsefulTask("cln", "clean", "Run clean"),
-      UsefulTask("c", "compile", "Run compile"),
-      UsefulTask("cc", "+compile", "Run cross-scalaVersion compile"),
-      UsefulTask("tc", "Test/compile", "Run Test/compile"),
-      UsefulTask("ctc", "+Test/compile", "Run cross-scalaVersion Test/compile"),
-      UsefulTask("t", "test", "Run test"),
-      UsefulTask("ct", "+test", "Run cross-scalaVersion test"),
-      UsefulTask("fmtchk", "scalafmtCheckAll", "Run scalafmtCheckAll"),
-      UsefulTask("fmt", "scalafmtAll", "Run scalafmtAll"),
-      UsefulTask("cfmtchk", "+scalafmtCheckAll", "Run +scalafmtCheckAll"),
-      UsefulTask("cfmt", "+scalafmtAll", "Run +scalafmtAll"),
-      UsefulTask("fixchk", "scalafixAll --check", "Run scalafixAll --check"),
-      UsefulTask("fix", "scalafixAll", "Run scalafixAll"),
-      UsefulTask("cfixchk", "+scalafixAll --check", "Run +scalafixAll --check"),
-      UsefulTask("cfix", "+scalafixAll", "Run +scalafixAll"),
-      UsefulTask("chk", "fmtchk; fixchk", "Run scalafmtCheckAll; scalafixAll --check"),
-      UsefulTask("cchk", "cfmtchk; cfixchk", "Run +scalafmtCheckAll; +scalafixAll --check"),
-      UsefulTask("pl", "publishLocal", "Run publishLocal"),
-    ),
+      UsefulTask("reload", "Run reload").alias("r"),
+      UsefulTask("clean", "Run clean").alias("cln"),
+      UsefulTask("compile", "Run compile").alias("c"),
+      UsefulTask("+compile", "Run cross-scalaVersion compile").alias("cc"),
+      UsefulTask("Test/compile", "Run Test/compile").alias("tc"),
+      UsefulTask("+Test/compile", "Run cross-scalaVersion Test/compile").alias("ctc"),
+      UsefulTask("test", "Run test").alias("t"),
+      UsefulTask("+test", "Run cross-scalaVersion test").alias("ct"),
+      UsefulTask("scalafmtCheckAll", "Run scalafmtCheckAll").alias("fmtchk"),
+      UsefulTask("scalafmtAll", "Run scalafmtAll").alias("fmt"),
+      UsefulTask("+scalafmtCheckAll", "Run +scalafmtCheckAll").alias("cfmtchk"),
+      UsefulTask("+scalafmtAll", "Run +scalafmtAll").alias("cfmt"),
+      UsefulTask("scalafixAll --check", "Run scalafixAll --check").alias("fixchk"),
+      UsefulTask("scalafixAll", "Run scalafixAll").alias("fix"),
+      UsefulTask("+scalafixAll --check", "Run +scalafixAll --check").alias("cfixchk"),
+      UsefulTask("+scalafixAll", "Run +scalafixAll").alias("cfix"),
+      UsefulTask("fmtchk; fixchk", "Run scalafmtCheckAll; scalafixAll --check").alias("chk"),
+      UsefulTask("cfmtchk; cfixchk", "Run +scalafmtCheckAll; +scalafixAll --check").alias("cchk"),
+      UsefulTask("publishLocal", "Run publishLocal").alias("pl"),
+    ).map(_.formatAlias(sbtWelcomeAliasFormatter)),
     logoColor := Color.magenta.toAnsi,
     aliasColor := Color.blue.toAnsi,
   )

--- a/modules/sbt-devoops-starter/src/sbt-test/sbt-devoops-starter/write-default-scalafix-conf-cross-scala-test-existing/build.sbt
+++ b/modules/sbt-devoops-starter/src/sbt-test/sbt-devoops-starter/write-default-scalafix-conf-cross-scala-test-existing/build.sbt
@@ -6,7 +6,7 @@ ThisBuild / organizationName := "example"
 ThisBuild / crossScalaVersions := List(
   "3.0.0",
   "2.13.8",
-  "2.12.17",
+  "2.12.18",
 )
 
 lazy val root = (project in file("."))

--- a/modules/sbt-devoops-starter/src/sbt-test/sbt-devoops-starter/write-default-scalafix-conf-cross-scala-test-existing/project/build.properties
+++ b/modules/sbt-devoops-starter/src/sbt-test/sbt-devoops-starter/write-default-scalafix-conf-cross-scala-test-existing/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.7.2
+sbt.version=1.9.7

--- a/modules/sbt-devoops-starter/src/sbt-test/sbt-devoops-starter/write-default-scalafix-conf-cross-scala-test-new/build.sbt
+++ b/modules/sbt-devoops-starter/src/sbt-test/sbt-devoops-starter/write-default-scalafix-conf-cross-scala-test-new/build.sbt
@@ -6,7 +6,7 @@ ThisBuild / organizationName := "example"
 ThisBuild / crossScalaVersions := List(
   "3.0.0",
   "2.13.8",
-  "2.12.17",
+  "2.12.18",
 )
 
 lazy val root = (project in file("."))

--- a/modules/sbt-devoops-starter/src/sbt-test/sbt-devoops-starter/write-default-scalafix-conf-cross-scala-test-new/project/build.properties
+++ b/modules/sbt-devoops-starter/src/sbt-test/sbt-devoops-starter/write-default-scalafix-conf-cross-scala-test-new/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.7.2
+sbt.version=1.9.7

--- a/modules/sbt-devoops-starter/src/sbt-test/sbt-devoops-starter/write-default-scalafix-conf-scala2-test-existing/project/build.properties
+++ b/modules/sbt-devoops-starter/src/sbt-test/sbt-devoops-starter/write-default-scalafix-conf-scala2-test-existing/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.7.2
+sbt.version=1.9.7

--- a/modules/sbt-devoops-starter/src/sbt-test/sbt-devoops-starter/write-default-scalafix-conf-scala2-test-new/project/build.properties
+++ b/modules/sbt-devoops-starter/src/sbt-test/sbt-devoops-starter/write-default-scalafix-conf-scala2-test-new/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.7.2
+sbt.version=1.9.7

--- a/modules/sbt-devoops-starter/src/sbt-test/sbt-devoops-starter/write-default-scalafix-conf-scala3-test-existing/project/build.properties
+++ b/modules/sbt-devoops-starter/src/sbt-test/sbt-devoops-starter/write-default-scalafix-conf-scala3-test-existing/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.7.2
+sbt.version=1.9.7

--- a/modules/sbt-devoops-starter/src/sbt-test/sbt-devoops-starter/write-default-scalafix-conf-scala3-test-new/project/build.properties
+++ b/modules/sbt-devoops-starter/src/sbt-test/sbt-devoops-starter/write-default-scalafix-conf-scala3-test-new/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.7.2
+sbt.version=1.9.7

--- a/modules/sbt-devoops-starter/src/sbt-test/sbt-devoops-starter/write-default-scalafmt-conf-test-existing/build.sbt
+++ b/modules/sbt-devoops-starter/src/sbt-test/sbt-devoops-starter/write-default-scalafmt-conf-test-existing/build.sbt
@@ -5,7 +5,7 @@ ThisBuild / organizationName := "example"
 
 ThisBuild / crossScalaVersions := List(
   "2.13.8",
-  "2.12.17",
+  "2.12.18",
   "2.11.12",
 )
 

--- a/modules/sbt-devoops-starter/src/sbt-test/sbt-devoops-starter/write-default-scalafmt-conf-test-existing/project/build.properties
+++ b/modules/sbt-devoops-starter/src/sbt-test/sbt-devoops-starter/write-default-scalafmt-conf-test-existing/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.7.2
+sbt.version=1.9.7

--- a/modules/sbt-devoops-starter/src/sbt-test/sbt-devoops-starter/write-default-scalafmt-conf-test-new/build.sbt
+++ b/modules/sbt-devoops-starter/src/sbt-test/sbt-devoops-starter/write-default-scalafmt-conf-test-new/build.sbt
@@ -5,7 +5,7 @@ ThisBuild / organizationName := "example"
 
 ThisBuild / crossScalaVersions := List(
   "2.13.8",
-  "2.12.17",
+  "2.12.18",
   "2.11.12",
 )
 

--- a/modules/sbt-devoops-starter/src/sbt-test/sbt-devoops-starter/write-default-scalafmt-conf-test-new/project/build.properties
+++ b/modules/sbt-devoops-starter/src/sbt-test/sbt-devoops-starter/write-default-scalafmt-conf-test-new/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.7.2
+sbt.version=1.9.7

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.8.0
+sbt.version=1.9.7

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,17 +1,18 @@
 logLevel := sbt.Level.Warn
 
-addSbtPlugin("com.github.sbt"   % "sbt-ci-release"            % "1.5.10")
-addSbtPlugin("org.wartremover"  % "sbt-wartremover"           % "3.0.6")
-addSbtPlugin("org.scoverage"    % "sbt-scoverage"             % "2.0.6")
-addSbtPlugin("org.scoverage"    % "sbt-coveralls"             % "1.3.2")
+addSbtPlugin("com.github.sbt"   % "sbt-ci-release"            % "1.5.12")
+addSbtPlugin("org.wartremover"  % "sbt-wartremover"           % "3.1.3")
+addSbtPlugin("org.scoverage"    % "sbt-scoverage"             % "2.0.9")
+addSbtPlugin("org.scoverage"    % "sbt-coveralls"             % "1.3.11")
 addSbtPlugin("org.lyranthe.sbt" % "partial-unification"       % "1.1.2")
 addSbtPlugin("com.timushev.sbt" % "sbt-updates"               % "0.6.3")
-addSbtPlugin("com.github.cb372" % "sbt-explicit-dependencies" % "0.2.16")
+addSbtPlugin("com.github.cb372" % "sbt-explicit-dependencies" % "0.3.1")
 
-addSbtPlugin("com.github.reibitto" % "sbt-welcome"  % "0.2.2")
-addSbtPlugin("io.kevinlee"         % "sbt-docusaur" % "0.13.0")
+addSbtPlugin("com.github.reibitto" % "sbt-welcome" % "0.4.0")
 
-val sbtDevOopsVersion = "2.24.0"
+addSbtPlugin("io.kevinlee" % "sbt-docusaur" % "0.13.0")
+
+val sbtDevOopsVersion = "2.24.1"
 addSbtPlugin("io.kevinlee" % "sbt-devoops-scala"     % sbtDevOopsVersion)
 addSbtPlugin("io.kevinlee" % "sbt-devoops-sbt-extra" % sbtDevOopsVersion)
 addSbtPlugin("io.kevinlee" % "sbt-devoops-github"    % sbtDevOopsVersion)


### PR DESCRIPTION
# Summary
Close #418 - Upgrade Scala, sbt, sbt plugins and libraries
* Scala to 2.12.18
* sbt to 1.9.7
* sbt-scalafmt to 2.5.2
* sbt-scalafix to 0.11.1
* sbt-ci-release to 1.5.12
* sbt-wartremover to 3.1.3
* sbt-scoverage to 2.0.9
* sbt-coveralls to 1.3.11
* sbt-explicit-dependencies to 0.3.1
* sbt-welcome to 0.4.0
* sbt-devoops to 2.24.1
