### PR TITLE
sbt-devoops v3.0.0

### DIFF
--- a/changelogs/3.0.0.md
+++ b/changelogs/3.0.0.md
@@ -1,0 +1,29 @@
+## [3.0.0](https://github.com/Kevin-Lee/sbt-devoops/issues?q=is%3Aissue+is%3Aclosed+-label%3Adeclined+milestone%3Amilestone35) - 2023-11-19
+
+### Breaking Changes
+* [`sbt-devoops-scala`] Remove `scalacOptions` in favor of `sbt-tpolecat` (#424)
+  * Now, `sbt-devoops-scala` requires `sbt-tpolecat`, so having `sbt-devoops-scala` also means having `sbt-tpolecat`.
+
+### Internal Housekeeping
+* Upgrade Scala, sbt, sbt plugins and libraries (#418)
+  * Scala to `2.12.18`
+  * sbt to `1.9.7`
+  * sbt-scalafmt to `2.5.2`
+  * sbt-scalafix to `0.11.1`
+  * sbt-ci-release to `1.5.12`
+  * sbt-wartremover to `3.1.3`
+  * sbt-scoverage to `2.0.9`
+  * sbt-coveralls to `1.3.11`
+  * sbt-explicit-dependencies to `0.3.1`
+  * sbt-welcome to `0.4.0`
+  * sbt-devoops to `2.24.1`
+* Upgrade libraries (#421)
+  * cats to `2.10.0`
+  * cats-effect to `3.5.2`
+  * extras to `0.44.0`
+  * effectie to `2.0.0-beta13`
+  * logger-f to `2.0.0-beta22`
+  * refined to `0.11.0`
+  * circe to `0.14.6`
+  * http4s to `0.23.24`
+  * just-semver to `0.13.0`


### PR DESCRIPTION
# sbt-devoops v3.0.0
## [3.0.0](https://github.com/Kevin-Lee/sbt-devoops/issues?q=is%3Aissue+is%3Aclosed+-label%3Adeclined+milestone%3Amilestone35) - 2023-11-19

### Breaking Changes
* [`sbt-devoops-scala`] Remove `scalacOptions` in favor of `sbt-tpolecat` (#424)
  * Now, `sbt-devoops-scala` requires `sbt-tpolecat`, so having `sbt-devoops-scala` also means having `sbt-tpolecat`.

### Internal Housekeeping
* Upgrade Scala, sbt, sbt plugins and libraries (#418)
  * Scala to `2.12.18`
  * sbt to `1.9.7`
  * sbt-scalafmt to `2.5.2`
  * sbt-scalafix to `0.11.1`
  * sbt-ci-release to `1.5.12`
  * sbt-wartremover to `3.1.3`
  * sbt-scoverage to `2.0.9`
  * sbt-coveralls to `1.3.11`
  * sbt-explicit-dependencies to `0.3.1`
  * sbt-welcome to `0.4.0`
  * sbt-devoops to `2.24.1`
* Upgrade libraries (#421)
  * cats to `2.10.0`
  * cats-effect to `3.5.2`
  * extras to `0.44.0`
  * effectie to `2.0.0-beta13`
  * logger-f to `2.0.0-beta22`
  * refined to `0.11.0`
  * circe to `0.14.6`
  * http4s to `0.23.24`
  * just-semver to `0.13.0`
