### PR TITLE
sbt-devoops v3.1.0

### DIFF
--- a/changelogs/3.1.0.md
+++ b/changelogs/3.1.0.md
@@ -1,0 +1,15 @@
+## [3.1.0](https://github.com/Kevin-Lee/sbt-devoops/issues?q=is%3Aissue+is%3Aclosed+-label%3Adeclined+milestone%3Amilestone36) - 2024-03-03
+
+### New Feature
+* [`sbt-devoops-scala`] Add `-Ymacro-annotations` to `scalacOptions` for Scala `2.13.3` and higher (#441)
+
+### Changes
+* [`sbt-devoops-scala`] Update `kind-projector` version for new Scala `2.13`, `2.12` and `2.11` (#437)
+
+### Internal Housekeeping
+* Bump libraries (#439)
+  * `cats-effect` to `3.5.3`
+  * `effectie` to `2.0.0-beta14`
+  * `logger-f` to `2.0.0-beta24`
+  * `refined` to `0.11.1`
+  * `http4s` to `0.23.25`


### PR DESCRIPTION
# sbt-devoops v3.1.0
## [3.1.0](https://github.com/Kevin-Lee/sbt-devoops/issues?q=is%3Aissue+is%3Aclosed+-label%3Adeclined+milestone%3Amilestone36) - 2024-03-03

### New Feature
* [`sbt-devoops-scala`] Add `-Ymacro-annotations` to `scalacOptions` for Scala `2.13.3` and higher (#441)

### Changes
* [`sbt-devoops-scala`] Update `kind-projector` version for new Scala `2.13`, `2.12` and `2.11` (#437)

### Internal Housekeeping
* Bump libraries (#439)
  * `cats-effect` to `3.5.3`
  * `effectie` to `2.0.0-beta14`
  * `logger-f` to `2.0.0-beta24`
  * `refined` to `0.11.1`
  * `http4s` to `0.23.25`
