### PR TITLE
Update dependencies and plugins

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -145,7 +145,7 @@ def subProject(projectName: String): Project = {
       organization := props.Org,
       name := prefixedName,
       addCompilerPlugin("org.scalamacros" % "paradise"       % "2.1.1" cross CrossVersion.full),
-      addCompilerPlugin("org.typelevel"   % "kind-projector" % "0.13.2" cross CrossVersion.full),
+      addCompilerPlugin("org.typelevel"   % "kind-projector" % "0.13.3" cross CrossVersion.full),
 //      scalacOptions ++= List("-Xsource:3"),
       Compile / console / scalacOptions := scalacOptions.value diff List("-Ywarn-unused-import", "-Xfatal-warnings"),
       Compile / compile / wartremoverErrors ++= commonWarts,
@@ -198,42 +198,43 @@ lazy val props =
 
     val CrossSbtVersions = List(GlobalSbtVersion).distinct
 
-    val hedgehogVersion = "0.10.1"
+    val hedgehogVersion = "0.12.0"
 
     val newtypeVersion = "0.4.4"
 
-    val catsVersion       = "2.10.0"
-    val catsEffectVersion = "3.5.3"
+    val catsVersion       = "2.13.0"
+    val catsEffectVersion = "3.5.7"
 
     val extrasVersion = "0.44.0"
 
-    val effectieVersion = "2.0.0-beta14"
-    val loggerFVersion  = "2.0.0-beta24"
+    val effectieVersion = "2.0.0"
+    val loggerFVersion  = "2.1.18"
 
-    val refinedVersion = "0.11.1"
+    val refinedVersion = "0.11.3"
 
-    val circeVersion = "0.14.6"
+    val circeVersion        = "0.14.12"
+    val circeRefinedVersion = "0.15.1"
 
-    val http4sVersion = "0.23.25"
+    val http4sVersion = "0.23.30"
 
-    val justSemVerVersion = "0.13.0"
+    val justSemVerVersion = "1.1.1"
 
     val justSysprocessVersion = "1.0.0"
 
-    val commonsIoVersion = "2.11.0"
+    val commonsIoVersion = "2.18.0"
 
     val activationVersion    = "1.1.1"
     val activationApiVersion = "1.2.0"
 
-    val SbtTpolecatVersion = "0.5.0"
+    val SbtTpolecatVersion = "0.5.2"
 
     val SbtVersionPolicyVersion = "3.2.1"
-    val SbtReleaseVersion       = "1.1.0"
+    val SbtReleaseVersion       = "1.4.0"
 
-    val SbtScalafmtVersion = "2.5.2"
-    val SbtScalafixVersion = "0.11.1"
+    val SbtScalafmtVersion = "2.5.4"
+    val SbtScalafixVersion = "0.14.2"
 
-    val SbtWelcomeVersion = "0.4.0"
+    val SbtWelcomeVersion = "0.5.0"
 
     val IncludeTest = "compile->compile;test->test"
   }
@@ -278,7 +279,8 @@ lazy val libs =
     lazy val circe = List(
       "io.circe" %% "circe-generic" % props.circeVersion,
       "io.circe" %% "circe-parser"  % props.circeVersion,
-      "io.circe" %% "circe-refined" % props.circeVersion,
+    ) ++ List(
+      "io.circe" %% "circe-refined" % props.circeRefinedVersion
     )
 
     lazy val semVer = "io.kevinlee" %% "just-semver" % props.justSemVerVersion

--- a/modules/sbt-devoops-common/src/main/scala/kevinlee/sbt/io/Io.scala
+++ b/modules/sbt-devoops-common/src/main/scala/kevinlee/sbt/io/Io.scala
@@ -23,7 +23,11 @@ object Io {
       )
 
   def wildcardFilters(names: Seq[String], caseSensitivity: CaseSensitivity): FileFilter =
-    new WildcardFileFilter(names.toArray, CaseSensitivity.toIOCase(caseSensitivity))
+    WildcardFileFilter
+      .builder()
+      .setWildcards(names*)
+      .setIoCase(CaseSensitivity.toIOCase(caseSensitivity))
+      .get()
 
   def wildcardFilter(caseSensitivity: CaseSensitivity, name: String, names: String*): FileFilter =
     wildcardFilters(name +: names.toSeq, caseSensitivity)

--- a/modules/sbt-devoops-release-version-policy/src/main/scala/devoops/DevOopsReleaseVersionPolicyPlugin.scala
+++ b/modules/sbt-devoops-release-version-policy/src/main/scala/devoops/DevOopsReleaseVersionPolicyPlugin.scala
@@ -146,7 +146,7 @@ object DevOopsReleaseVersionPolicyPlugin extends AutoPlugin {
         (maybeBump match {
           case Some(bump) => versionWithoutQualifier.bump(bump)
           case None => versionWithoutQualifier
-        }).string
+        }).unapply
       }
     },
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -8,7 +8,7 @@ addSbtPlugin("org.lyranthe.sbt" % "partial-unification"       % "1.1.2")
 addSbtPlugin("com.timushev.sbt" % "sbt-updates"               % "0.6.3")
 addSbtPlugin("com.github.cb372" % "sbt-explicit-dependencies" % "0.3.1")
 
-addSbtPlugin("com.github.reibitto" % "sbt-welcome" % "0.4.0")
+addSbtPlugin("com.github.reibitto" % "sbt-welcome" % "0.5.0")
 
 addSbtPlugin("io.kevinlee" % "sbt-docusaur" % "0.16.0")
 


### PR DESCRIPTION
Update dependencies and plugins

- Updated `kind-projector` compiler plugin from 0.13.2 to 0.13.3
- Updated `hedgehog` from 0.10.1 to 0.12.0
- Updated `cats` from 2.10.0 to 2.13.0
- Updated `cats-effect` from 3.5.3 to 3.5.7
- Updated `effectie` from 2.0.0-beta14 to 2.0.0
- Updated `logger-f` from 2.0.0-beta24 to 2.1.18
- Updated `refined` from 0.11.1 to 0.11.3
- Updated `circe` from 0.14.6 to 0.14.12
- Added `circe-refined` version 0.15.1
- Updated `http4s` from 0.23.25 to 0.23.30
- Updated `just-semver` from 0.13.0 to 1.1.1
- Updated `commons-io` from 2.11.0 to 2.18.0
- Updated `sbt-tpolecat` from 0.5.0 to 0.5.2
- Updated `sbt-version-policy` from 3.2.1 to 3.2.1
- Updated `sbt-release` from 1.1.0 to 1.4.0
- Updated `sbt-scalafmt` from 2.5.2 to 2.5.4
- Updated `sbt-scalafix` from 0.11.1 to 0.14.2
- Updated `sbt-welcome` from 0.4.0 to 0.5.0

- Refactored `Io.scala` to use `WildcardFileFilter.builder()`
- Fixed `DevOopsReleaseVersionPolicyPlugin.scala` to use `unapply` instead of `string` for version bumping