### PR TITLE
sbt-devoops v3.2.0

### DIFF
--- a/changelogs/3.2.0.md
+++ b/changelogs/3.2.0.md
@@ -1,0 +1,26 @@
+## [3.2.0](https://github.com/Kevin-Lee/sbt-devoops/issues?q=is%3Aissue%20is%3Aclosed%20-label%3Adeclined%20milestone%3Amilestone37) - 2025-04-06
+
+### Internal Housekeeping
+* Bump `sbt-version-policy` to 3.2.1 (#454)
+* Bump libraries (#464)
+  - Updated `kind-projector` compiler plugin from 0.13.2 to 0.13.3
+  - Updated `hedgehog` from 0.10.1 to 0.12.0
+  - Updated `cats` from 2.10.0 to 2.13.0
+  - Updated `cats-effect` from 3.5.3 to 3.5.7
+  - Updated `effectie` from 2.0.0-beta14 to 2.0.0
+  - Updated `logger-f` from 2.0.0-beta24 to 2.1.18
+  - Updated `refined` from 0.11.1 to 0.11.3
+  - Updated `circe` from 0.14.6 to 0.14.12
+  - Added `circe-refined` version 0.15.1
+  - Updated `http4s` from 0.23.25 to 0.23.30
+  - Updated `just-semver` from 0.13.0 to 1.1.1
+  - Updated `commons-io` from 2.11.0 to 2.18.0
+  - Updated `sbt-tpolecat` from 0.5.0 to 0.5.2
+  - Updated `sbt-version-policy` from 3.2.1 to 3.2.1
+  - Updated `sbt-release` from 1.1.0 to 1.4.0
+  - Updated `sbt-scalafmt` from 2.5.2 to 2.5.4
+  - Updated `sbt-scalafix` from 0.11.1 to 0.14.2
+  - Updated `sbt-welcome` from 0.4.0 to 0.5.0
+
+  - Refactored `Io.scala` to use `WildcardFileFilter.builder()`
+  - Fixed `DevOopsReleaseVersionPolicyPlugin.scala` to use `unapply` instead of `string` for version bumping


### PR DESCRIPTION
# sbt-devoops v3.2.0
## [3.2.0](https://github.com/Kevin-Lee/sbt-devoops/issues?q=is%3Aissue%20is%3Aclosed%20-label%3Adeclined%20milestone%3Amilestone37) - 2025-04-06

### Internal Housekeeping
* Bump `sbt-version-policy` to 3.2.1 (#454)
* Bump libraries (#464)
  - Updated `kind-projector` compiler plugin from 0.13.2 to 0.13.3
  - Updated `hedgehog` from 0.10.1 to 0.12.0
  - Updated `cats` from 2.10.0 to 2.13.0
  - Updated `cats-effect` from 3.5.3 to 3.5.7
  - Updated `effectie` from 2.0.0-beta14 to 2.0.0
  - Updated `logger-f` from 2.0.0-beta24 to 2.1.18
  - Updated `refined` from 0.11.1 to 0.11.3
  - Updated `circe` from 0.14.6 to 0.14.12
  - Added `circe-refined` version 0.15.1
  - Updated `http4s` from 0.23.25 to 0.23.30
  - Updated `just-semver` from 0.13.0 to 1.1.1
  - Updated `commons-io` from 2.11.0 to 2.18.0
  - Updated `sbt-tpolecat` from 0.5.0 to 0.5.2
  - Updated `sbt-version-policy` from 3.2.1 to 3.2.1
  - Updated `sbt-release` from 1.1.0 to 1.4.0
  - Updated `sbt-scalafmt` from 2.5.2 to 2.5.4
  - Updated `sbt-scalafix` from 0.11.1 to 0.14.2
  - Updated `sbt-welcome` from 0.4.0 to 0.5.0

  - Refactored `Io.scala` to use `WildcardFileFilter.builder()`
  - Fixed `DevOopsReleaseVersionPolicyPlugin.scala` to use `unapply` instead of `string` for version bumping
