### PR TITLE
Update docs, and sbt-docusaur and sbt-devoops versions

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -10,9 +10,9 @@ addSbtPlugin("com.github.cb372" % "sbt-explicit-dependencies" % "0.3.1")
 
 addSbtPlugin("com.github.reibitto" % "sbt-welcome" % "0.5.0")
 
-addSbtPlugin("io.kevinlee" % "sbt-docusaur" % "0.16.0")
+addSbtPlugin("io.kevinlee" % "sbt-docusaur" % "0.17.0")
 
-val sbtDevOopsVersion = "3.1.0"
+val sbtDevOopsVersion = "3.2.0"
 addSbtPlugin("io.kevinlee" % "sbt-devoops-scala"     % sbtDevOopsVersion)
 addSbtPlugin("io.kevinlee" % "sbt-devoops-sbt-extra" % sbtDevOopsVersion)
 addSbtPlugin("io.kevinlee" % "sbt-devoops-github"    % sbtDevOopsVersion)

--- a/website/docs/getting-started.md
+++ b/website/docs/getting-started.md
@@ -21,15 +21,15 @@ SBT Plugin to help release artifacts and changelogs
 
 :::tip Note
 
-Documentation for `3.1.0` is a work in progress.
+Documentation for `3.2.0` is a work in progress.
 
 :::
 
 In the `project/plugins.sbt`, add the following line,
 ```scala
-addSbtPlugin("io.kevinlee" % "sbt-devoops-scala"     % "3.1.0")
-addSbtPlugin("io.kevinlee" % "sbt-devoops-sbt-extra" % "3.1.0")
-addSbtPlugin("io.kevinlee" % "sbt-devoops-starter"   % "3.1.0")
+addSbtPlugin("io.kevinlee" % "sbt-devoops-scala"     % "3.2.0")
+addSbtPlugin("io.kevinlee" % "sbt-devoops-sbt-extra" % "3.2.0")
+addSbtPlugin("io.kevinlee" % "sbt-devoops-starter"   % "3.2.0")
 ```
 
 ### DevOopsGitHubReleasePlugin

--- a/website/docs/gh-release-plugin/examples.md
+++ b/website/docs/gh-release-plugin/examples.md
@@ -9,7 +9,7 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 
 `PROJECT_ROOT/project/plugins.sbt`
 ```scala
-addSbtPlugin("io.kevinlee" % "sbt-devoops" % "3.1.0")
+addSbtPlugin("io.kevinlee" % "sbt-devoops" % "3.2.0")
 ```
 
 ## A Single Project

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -125,7 +125,7 @@ const websiteConfig = {
               "path": "2.24.1",
             },
             "current": {
-              "label": "3.1.0",
+              "label": "3.2.0",
             },
           },
         },

--- a/website/src/pages/versions.js
+++ b/website/src/pages/versions.js
@@ -24,6 +24,10 @@ function Version() {
     (version) => version !== latestVersion && version.name !== 'current',
   ).concat([
     {
+      "name": "3.1.0",
+      "label": "3.1.0",
+    },
+    {
       "name": "3.0.0",
       "label": "3.0.0",
     },


### PR DESCRIPTION
# Update docs, and sbt-docusaur and sbt-devoops versions

- Updated `sbt-docusaur` from 0.16.0 to 0.17.0
- Updated `sbt-devoops` version from 3.1.0 to 3.2.0 in `plugins.sbt`
- Updated `current` version label from 3.1.0 to 3.2.0 in `docusaurus.config.ts`
- Added version 3.1.0 to past versions in `versions.js`
