### PR TITLE
Fix #467 - Setting up `devOopsLogLevel` fails as it is imported twice

### DIFF
--- a/modules/sbt-devoops-common/src/main/scala/devoops/data/CommonKeys.scala
+++ b/modules/sbt-devoops-common/src/main/scala/devoops/data/CommonKeys.scala
@@ -6,6 +6,9 @@ import sbt.*
   * @since 2022-05-28
   */
 trait CommonKeys {
+  lazy val devOopsLogLevel: SettingKey[String] = CommonKeys.devOopsLogLevel
+}
+object CommonKeys {
 
   lazy val devOopsLogLevel: SettingKey[String] = settingKey(
     "Log level for DevOops tasks. It can be one of debug, info, warn and error (default: info)"


### PR DESCRIPTION
# Summary
Fix #467 - Setting up `devOopsLogLevel` fails as it is imported twice