### PR TITLE
Close #469 - `s01.oss.sonatype.org` will be sunset on the 30th of June, 2025 - So the new release should be published to the Sonatype Central Portal, the new Maven Central Repository

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -21,7 +21,6 @@ ThisBuild / licenses := List("MIT" -> url("http://opensource.org/licenses/MIT"))
 ThisBuild / startYear := 2018.some
 ThisBuild / testFrameworks ~=
   (frameworks => (TestFramework("hedgehog.sbt.Framework") +: frameworks).distinct)
-ThisBuild / resolvers += "sonatype-snapshots" at s"https://${props.SonatypeCredentialHost}/content/repositories/snapshots"
 
 Global / sbtVersion := props.GlobalSbtVersion
 
@@ -39,7 +38,6 @@ lazy val sbtDevOops = Project(props.ProjectName, file("."))
     gitHubPagesRepoName := props.ProjectName,
     publishMavenStyle := true,
   )
-  .settings(mavenCentralPublishSettings)
   .dependsOn(
     sbtDevOopsCommon,
     sbtDevOopsScala,
@@ -127,13 +125,6 @@ lazy val sbtDevOopsReleaseVersionPolicy = subProject(props.SubProjectNameRelease
 lazy val sbtDevOopsJava = subProject(props.SubProjectNameJava)
   .enablePlugins(SbtPlugin)
 
-lazy val mavenCentralPublishSettings: SettingsDefinition = List(
-  /* Publish to Maven Central { */
-  sonatypeCredentialHost := props.SonatypeCredentialHost,
-  sonatypeRepository := props.SonatypeRepository,
-  /* } Publish to Maven Central */
-)
-
 // scalafmt: off
 def prefixedProjectName(name: String) = s"${props.RepoName}${if (name.isEmpty) "" else s"-$name"}"
 // scalafmt: on
@@ -164,7 +155,6 @@ def subProject(projectName: String): Project = {
       },
       scriptedBufferLog := false,
     )
-    .settings(mavenCentralPublishSettings)
 }
 
 lazy val props =
@@ -177,9 +167,6 @@ lazy val props =
     val RepoName       = GitHubRepo.fold("sbt-devoops")(_.nameToString)
 
     val ProjectName = RepoName
-
-    val SonatypeCredentialHost = "s01.oss.sonatype.org"
-    val SonatypeRepository     = s"https://$SonatypeCredentialHost/service/local"
 
     val SubProjectNameCommon               = "common"
     val SubProjectNameScala                = "scala"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.10.7
+sbt.version=1.11.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 logLevel := sbt.Level.Warn
 
-addSbtPlugin("com.github.sbt"   % "sbt-ci-release"            % "1.5.12")
+addSbtPlugin("com.github.sbt"   % "sbt-ci-release"            % "1.11.1")
 addSbtPlugin("org.wartremover"  % "sbt-wartremover"           % "3.1.3")
 addSbtPlugin("org.scoverage"    % "sbt-scoverage"             % "2.0.9")
 addSbtPlugin("org.scoverage"    % "sbt-coveralls"             % "1.3.11")


### PR DESCRIPTION
# Summary
Close #469 - [s01.oss.sonatype.org](s01.oss.sonatype.org) will be sunset on the 30th of June, 2025 - So the new release should be published to the Sonatype Central Portal, the new Maven Central Repository

Upgrade `sbt` to `1.11.2` and the `sbt-ci-release` plugin to `1.11.1` / clean up unused build settings related to the old Maven Central (OSSRH).

Due to the end-of-life (sunset) of OSSRH, upgrading `sbt` to `1.11.2` and `sbt-ci-release` to `1.11.1` was required in order to publish artifacts to the Central Publisher Portal (Maven Central).
