### PR TITLE
sbt-devoops v3.2.1

### DIFF
--- a/changelogs/3.2.1.md
+++ b/changelogs/3.2.1.md
@@ -1,0 +1,21 @@
+## [3.2.1](https://github.com/Kevin-Lee/sbt-devoops/issues?q=is%3Aissue%20is%3Aclosed%20-label%3Adeclined%20milestone%3Amilestone38) - 2025-06-18
+
+### Fixed
+* Setting up devOopsLogLevel fails as it is imported twice (#467)
+
+### Internal Housekeeping
+* `s01.oss.sonatype.org` will be sunset on the 30th of June, 2025 (#469)
+
+  So it will no longer be possible to publish the artifacts to s01.oss.sonatype.org.
+
+  https://central.sonatype.org/news/20250326_ossrh_sunset/
+  > Announcement of the End-of-Life Sunset Date for OSSRH[⚓︎](https://central.sonatype.org/news/20250326_ossrh_sunset/#announcement-of-the-end-of-life-sunset-date-for-ossrh)
+  > The [OSSRH service](https://central.sonatype.org/publish/publish-guide/) will reach end-of-life on June 30th, 2025. This coincides with the [end-of-life date of the underlying technology, Sonatype's Nexus Repository Manager v2](https://help.sonatype.com/en/sonatype-nexus-repository-2-sunsetting-information.html).
+
+  So the new release should be published to the `Sonatype Central Portal`, the new Maven Central Repository.
+
+  Done for releasing to the new Sonatype Central Portal (Maven Central):
+
+  Upgrade `sbt` to `1.11.2` and the `sbt-ci-release` plugin to `1.11.1` / clean up unused build settings related to the old Maven Central (OSSRH).
+
+  Due to the end-of-life (sunset) of OSSRH, upgrading `sbt` to `1.11.2` and `sbt-ci-release` to `1.11.1` was required in order to publish artifacts to the Central Publisher Portal (Maven Central).


### PR DESCRIPTION
# sbt-devoops v3.2.1
## [3.2.1](https://github.com/Kevin-Lee/sbt-devoops/issues?q=is%3Aissue%20is%3Aclosed%20-label%3Adeclined%20milestone%3Amilestone38) - 2025-06-18

### Fixed
* Setting up devOopsLogLevel fails as it is imported twice (#467)

### Internal Housekeeping
* `s01.oss.sonatype.org` will be sunset on the 30th of June, 2025 (#469)

  So it will no longer be possible to publish the artifacts to s01.oss.sonatype.org.

  https://central.sonatype.org/news/20250326_ossrh_sunset/
  > Announcement of the End-of-Life Sunset Date for OSSRH[⚓︎](https://central.sonatype.org/news/20250326_ossrh_sunset/#announcement-of-the-end-of-life-sunset-date-for-ossrh)
  > The [OSSRH service](https://central.sonatype.org/publish/publish-guide/) will reach end-of-life on June 30th, 2025. This coincides with the [end-of-life date of the underlying technology, Sonatype's Nexus Repository Manager v2](https://help.sonatype.com/en/sonatype-nexus-repository-2-sunsetting-information.html).

  So the new release should be published to the `Sonatype Central Portal`, the new Maven Central Repository.

  Done for releasing to the new Sonatype Central Portal (Maven Central):

  Upgrade `sbt` to `1.11.2` and the `sbt-ci-release` plugin to `1.11.1` / clean up unused build settings related to the old Maven Central (OSSRH).

  Due to the end-of-life (sunset) of OSSRH, upgrading `sbt` to `1.11.2` and `sbt-ci-release` to `1.11.1` was required in order to publish artifacts to the Central Publisher Portal (Maven Central).
