### PR TITLE
sbt-devoops v3.3.0

### DIFF
--- a/changelogs/3.3.0.md
+++ b/changelogs/3.3.0.md
@@ -1,0 +1,25 @@
+## [3.3.0](https://github.com/Kevin-Lee/sbt-devoops/issues?q=is%3Aissue%20is%3Aclosed%20-label%3Adeclined%20milestone%3Am39) - 2025-10-11
+
+### Changes
+
+* Upgrade `kind-projector` from `0.13.3` to `0.13.4` (#478)
+  * `2.13._`: `0.13.3` => `0.13.4`
+  * `2.12.(_ >= 8)`: `0.13.3` => `0.13.4`
+  * `2.11.12`: `0.13.3` => `0.13.4`
+
+### Fixed
+
+* Type inference issue with `kind-polymorphic Nothing` in Scala `2.13.17` (#480)
+
+  For `F[*]`, there might be a compile-time warning like
+  ```
+  a type was inferred to be kind-polymorphic `Nothing` to conform to `F[*]`
+  ```
+  So the following suggested workaround `scalacOptions` was added for Scala `2.13.17`.
+  ```
+  "-Wconf:cat=lint-infer-any&msg=kind-polymorphic[\\s]+`Nothing`:s"
+  ```
+
+### Internal Housekeeping
+
+* Bump `sbt` to `1.11.7` (#482)


### PR DESCRIPTION
# sbt-devoops v3.3.0
## [3.3.0](https://github.com/Kevin-Lee/sbt-devoops/issues?q=is%3Aissue%20is%3Aclosed%20-label%3Adeclined%20milestone%3Am39) - 2025-10-11

### Changes

* Upgrade `kind-projector` from `0.13.3` to `0.13.4` (#478)
  * `2.13._`: `0.13.3` => `0.13.4`
  * `2.12.(_ >= 8)`: `0.13.3` => `0.13.4`
  * `2.11.12`: `0.13.3` => `0.13.4`

### Fixed

* Type inference issue with `kind-polymorphic Nothing` in Scala `2.13.17` (#480)

  For `F[*]`, there might be a compile-time warning like
  ```
  a type was inferred to be kind-polymorphic `Nothing` to conform to `F[*]`
  ```
  So the following suggested workaround `scalacOptions` was added for Scala `2.13.17`.
  ```
  "-Wconf:cat=lint-infer-any&msg=kind-polymorphic[\\s]+`Nothing`:s"
  ```

### Internal Housekeeping

* Bump `sbt` to `1.11.7` (#482)
