### PR TITLE
Close #485: Bump logger-f to 2.4.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -195,7 +195,7 @@ lazy val props =
     val extrasVersion = "0.49.0"
 
     val effectieVersion = "2.0.0"
-    val loggerFVersion  = "2.2.0"
+    val loggerFVersion  = "2.4.0"
 
     val refinedVersion = "0.11.3"
 

--- a/modules/sbt-devoops-github/src/main/scala/devoops/DevOopsGitHubPlugin.scala
+++ b/modules/sbt-devoops-github/src/main/scala/devoops/DevOopsGitHubPlugin.scala
@@ -6,7 +6,7 @@ import extras.cats.syntax.option.*
 import kevinlee.github.data.GitHub
 import effectie.instances.ce3.fx.*
 import loggerf.logger.{CanLog, SbtLogger}
-import loggerf.instances.cats.*
+
 import sbt.Keys.*
 import sbt.*
 

--- a/modules/sbt-devoops-github/src/main/scala/devoops/DevOopsGitHubReleasePlugin.scala
+++ b/modules/sbt-devoops-github/src/main/scala/devoops/DevOopsGitHubReleasePlugin.scala
@@ -16,7 +16,7 @@ import kevinlee.github.{GitHubApi, GitHubTask}
 import kevinlee.http.HttpClient
 import kevinlee.sbt.SbtCommon.messageOnlyException
 import kevinlee.sbt.io.{CaseSensitivity, Io}
-import loggerf.instances.cats.*
+
 import loggerf.logger.{CanLog, SbtLogger}
 import org.http4s.ember.client.EmberClientBuilder
 import sbt.Keys.*

--- a/modules/sbt-devoops-github/src/main/scala/devoops/data/Logging.scala
+++ b/modules/sbt-devoops-github/src/main/scala/devoops/data/Logging.scala
@@ -22,10 +22,18 @@ object Logging {
         (ignoreLogging, ignoreLogging, ignoreLogging, ignoreLogging)
     }
     new CanLog {
-      override def debug(message: => String): Unit = debugF(message)
-      override def info(message: => String): Unit  = infoF(message)
-      override def warn(message: => String): Unit  = warnF(message)
-      override def error(message: => String): Unit = errorF(message)
+      override def debug(message: => String): Unit                       = debugF(message)
+      override def debug(throwable: Throwable)(message: => String): Unit = debug(s"$message\n${throwable.toString}")
+
+      override def info(message: => String): Unit                       = infoF(message)
+      override def info(throwable: Throwable)(message: => String): Unit = info(s"$message\n${throwable.toString}")
+
+      override def warn(message: => String): Unit                       = warnF(message)
+      override def warn(throwable: Throwable)(message: => String): Unit = warn(s"$message\n${throwable.toString}")
+
+      override def error(message: => String): Unit                       = errorF(message)
+      override def error(throwable: Throwable)(message: => String): Unit = error(s"$message\n${throwable.toString}")
+
     }
   }
 

--- a/modules/sbt-devoops-starter/src/main/scala/devoops/DevOopsStarterPlugin.scala
+++ b/modules/sbt-devoops-starter/src/main/scala/devoops/DevOopsStarterPlugin.scala
@@ -20,7 +20,7 @@ import kevinlee.github.GitHubApi
 import kevinlee.github.data.GitHub
 import kevinlee.http.HttpClient
 import kevinlee.sbt.SbtCommon.*
-import loggerf.instances.cats.*
+
 import loggerf.core.Log as LogF
 import loggerf.logger.{CanLog, SbtLogger}
 import org.http4s.ember.client.EmberClientBuilder


### PR DESCRIPTION
## Close #485: Bump logger-f to 2.4.0

The older version of logger-f with the latest sbt-docusaur is causing `java.lang.NoSuchMethodError: 'loggerf.core.Log loggerf.instances.cats$.logF`
