### PR TITLE
sbt-devoops v3.3.1

### DIFF
--- a/changelogs/3.3.1.md
+++ b/changelogs/3.3.1.md
@@ -1,0 +1,19 @@
+## [3.3.1](https://github.com/Kevin-Lee/sbt-devoops/issues?q=is%3Aissue%20is%3Aclosed%20-label%3Adeclined%20milestone%3Am40) - 2025-10-14
+
+### Fixed
+
+* Bump `logger-f` to `2.4.0` to fix `NoSuchMethodError` (#485)
+
+  The older version of `logger-f` with the latest `sbt-docusaur` is causing the following error.
+  ```
+  java.lang.NoSuchMethodError: 'loggerf.core.Log loggerf.instances.cats$.logF(effectie.core.FxCtor, loggerf.logger.CanLog, cats.Monad)'
+	at devoops.DevOopsGitHubPlugin$.findRepoOrgAndNameWithCanLog(DevOopsGitHubPlugin.scala:42)
+	at devoops.DevOopsGitHubPlugin$.devoops$DevOopsGitHubPlugin$$findRepoOrgAndNameWithPrintlnLog(DevOopsGitHubPlugin.scala:36)
+	at devoops.DevOopsGitHubPlugin$autoImport$.findRepoOrgAndName(DevOopsGitHubPlugin.scala:28)
+  ```
+
+### Internal Housekeeping
+
+* Generate a file containing the latest version for docs (#487)
+
+  It is created at `website/latestVersion.json`.


### PR DESCRIPTION
# sbt-devoops
## [3.3.1](https://github.com/Kevin-Lee/sbt-devoops/issues?q=is%3Aissue%20is%3Aclosed%20-label%3Adeclined%20milestone%3Am40) - 2025-10-14

### Fixed

* Bump `logger-f` to `2.4.0` to fix `NoSuchMethodError` (#485)

  The older version of `logger-f` with the latest `sbt-docusaur` is causing the following error.
  ```
  java.lang.NoSuchMethodError: 'loggerf.core.Log loggerf.instances.cats$.logF(effectie.core.FxCtor, loggerf.logger.CanLog, cats.Monad)'
	at devoops.DevOopsGitHubPlugin$.findRepoOrgAndNameWithCanLog(DevOopsGitHubPlugin.scala:42)
	at devoops.DevOopsGitHubPlugin$.devoops$DevOopsGitHubPlugin$$findRepoOrgAndNameWithPrintlnLog(DevOopsGitHubPlugin.scala:36)
	at devoops.DevOopsGitHubPlugin$autoImport$.findRepoOrgAndName(DevOopsGitHubPlugin.scala:28)
  ```

### Internal Housekeeping

* Generate a file containing the latest version for docs (#487)

  It is created at `website/latestVersion.json`.
