### PR TITLE
Close #496: Update dependency libraries

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -149,7 +149,7 @@ def subProject(projectName: String): Project = {
       organization := props.Org,
       name := prefixedName,
       addCompilerPlugin("org.scalamacros" % "paradise"       % "2.1.1" cross CrossVersion.full),
-      addCompilerPlugin("org.typelevel"   % "kind-projector" % "0.13.3" cross CrossVersion.full),
+      addCompilerPlugin("org.typelevel"   % "kind-projector" % "0.13.4" cross CrossVersion.full),
 //      scalacOptions ++= List("-Xsource:3"),
       Compile / console / scalacOptions := scalacOptions.value diff List("-Ywarn-unused-import", "-Xfatal-warnings"),
       Compile / compile / wartremoverErrors ++= commonWarts,
@@ -205,23 +205,23 @@ lazy val props =
     val catsVersion       = "2.13.0"
     val catsEffectVersion = "3.6.3"
 
-    val extrasVersion = "0.49.0"
+    val extrasVersion = "0.50.1"
 
-    val effectieVersion = "2.0.0"
-    val loggerFVersion  = "2.4.0"
+    val effectieVersion = "2.3.0"
+    val loggerFVersion  = "2.8.1"
 
     val refinedVersion = "0.11.3"
 
-    val circeVersion        = "0.14.12"
+    val circeVersion        = "0.14.15"
     val circeRefinedVersion = "0.15.1"
 
-    val http4sVersion = "0.23.30"
+    val http4sVersion = "0.23.33"
 
     val justSemVerVersion = "1.1.1"
 
     val justSysprocessVersion = "1.0.0"
 
-    val commonsIoVersion = "2.20.0"
+    val commonsIoVersion = "2.21.0"
 
     val activationVersion    = "1.1.1"
     val activationApiVersion = "1.2.0"
@@ -231,8 +231,8 @@ lazy val props =
     val SbtVersionPolicyVersion = "3.2.1"
     val SbtReleaseVersion       = "1.4.0"
 
-    val SbtScalafmtVersion = "2.5.5"
-    val SbtScalafixVersion = "0.14.3"
+    val SbtScalafmtVersion = "2.5.6"
+    val SbtScalafixVersion = "0.14.5"
 
     val SbtWelcomeVersion = "0.5.0"
 

--- a/modules/sbt-devoops-github-core/src/main/scala/kevinlee/github/data/GitHubError.scala
+++ b/modules/sbt-devoops-github-core/src/main/scala/kevinlee/github/data/GitHubError.scala
@@ -275,7 +275,7 @@ object GitHubError {
           GitHubError.forbiddenRequest(httpRequest, httpResponse)
       }
 
-    case HttpError.UnprocessableEntity(request, response) =>
+    case HttpError.UnprocessableContent(request, response) =>
       val responseBodyJson = response.toFailedResponseBodyJson
       GitHubError.unprocessableEntity(request, response, responseBodyJson)
 

--- a/modules/sbt-devoops-http-core/src/main/scala/kevinlee/http/HttpClient.scala
+++ b/modules/sbt-devoops-http-core/src/main/scala/kevinlee/http/HttpClient.scala
@@ -154,8 +154,8 @@ object HttpClient {
             case Status.InternalServerError.code =>
               HttpError.internalServerError(httpResponse).asLeft[A]
 
-            case Status.UnprocessableEntity.code =>
-              HttpError.unprocessableEntity(httpRequest, httpResponse).asLeft[A]
+            case Status.UnprocessableContent.code =>
+              HttpError.unprocessableContent(httpRequest, httpResponse).asLeft[A]
 
             case Status.Unauthorized.code =>
               HttpError.unauthorized(httpRequest, httpResponse).asLeft[A]

--- a/modules/sbt-devoops-http-core/src/main/scala/kevinlee/http/HttpError.scala
+++ b/modules/sbt-devoops-http-core/src/main/scala/kevinlee/http/HttpError.scala
@@ -43,7 +43,7 @@ object HttpError {
     httpRequest: HttpRequest,
     httpResponse: HttpResponse,
   ) extends HttpError
-  final case class UnprocessableEntity(
+  final case class UnprocessableContent(
     httpRequest: HttpRequest,
     httpResponse: HttpResponse,
   ) extends HttpError
@@ -87,8 +87,8 @@ object HttpError {
   def forbidden(httpRequest: HttpRequest, httpResponse: HttpResponse): HttpError =
     Forbidden(httpRequest, httpResponse)
 
-  def unprocessableEntity(httpRequest: HttpRequest, httpResponse: HttpResponse): HttpError =
-    UnprocessableEntity(httpRequest, httpResponse)
+  def unprocessableContent(httpRequest: HttpRequest, httpResponse: HttpResponse): HttpError =
+    UnprocessableContent(httpRequest, httpResponse)
 
   def methodUnsupportedForMultipart(httpRequest: HttpRequest): HttpError =
     MethodUnsupportedForMultipart(httpRequest)
@@ -125,8 +125,8 @@ object HttpError {
     case Forbidden(httpRequest: HttpRequest, httpResponse: HttpResponse) =>
       s"Forbidden(httpRequest: ${httpRequest.show}, httpResponse: ${httpResponse.show})"
 
-    case UnprocessableEntity(httpRequest: HttpRequest, httpResponse: HttpResponse) =>
-      s"UnprocessableEntity(httpRequest: ${httpRequest.show}, httpResponse: ${httpResponse.show})"
+    case UnprocessableContent(httpRequest: HttpRequest, httpResponse: HttpResponse) =>
+      s"UnprocessableContent(httpRequest: ${httpRequest.show}, httpResponse: ${httpResponse.show})"
 
     case MethodUnsupportedForMultipart(httpRequest: HttpRequest) =>
       s"MethodUnsupportedForMultipart(httpRequest: ${httpRequest.show})"


### PR DESCRIPTION
## Close #496: Update dependency libraries

- Update dependencies in build.sbt:
  - `kind-projector`: `0.13.3` -> `0.13.4`
  - `extras`: `0.49.0` -> `0.50.1`
  - `effectie`: `2.0.0` -> `2.3.0`
  - `logger-f`: `2.4.0` -> `2.8.1`
  - `circe`: `0.14.12` -> `0.14.15`
  - `http4s`: `0.23.30` -> `0.23.33`
  - `commons-io`: `2.20.0` -> `2.21.0`
  - `sbt-scalafmt`: `2.5.5` -> `2.5.6`
  - `sbt-scalafix`: `0.14.3` -> `0.14.5`
- Rename `HttpError.UnprocessableEntity` to `HttpError.UnprocessableContent` as the corresponding error in http4s has changed.