### PR TITLE
sbt-devoops v3.3.2

### DIFF
--- a/changelogs/3.3.2.md
+++ b/changelogs/3.3.2.md
@@ -1,0 +1,14 @@
+## [3.3.2](https://github.com/Kevin-Lee/sbt-devoops/issues?q=is%3Aissue%20is%3Aclosed%20-label%3Adeclined%20milestone%3Am41) - 2025-12-29
+
+### Internal Housekeeping
+
+* Update dependency libraries (#496)
+  - `kind-projector`: `0.13.3` -> `0.13.4`
+  - `extras`: `0.49.0` -> `0.50.1`
+  - `effectie`: `2.0.0` -> `2.3.0`
+  - `logger-f`: `2.4.0` -> `2.8.1`
+  - `circe`: `0.14.12` -> `0.14.15`
+  - `http4s`: `0.23.30` -> `0.23.33`
+  - `commons-io`: `2.20.0` -> `2.21.0`
+  - `sbt-scalafmt`: `2.5.5` -> `2.5.6`
+  - `sbt-scalafix`: `0.14.3` -> `0.14.5`


### PR DESCRIPTION
# sbt-devoops v3.3.2

## [3.3.2](https://github.com/Kevin-Lee/sbt-devoops/issues?q=is%3Aissue%20is%3Aclosed%20-label%3Adeclined%20milestone%3Am41) - 2025-12-29

### Internal Housekeeping

* Update dependency libraries (#496)
  - `kind-projector`: `0.13.3` -> `0.13.4`
  - `extras`: `0.49.0` -> `0.50.1`
  - `effectie`: `2.0.0` -> `2.3.0`
  - `logger-f`: `2.4.0` -> `2.8.1`
  - `circe`: `0.14.12` -> `0.14.15`
  - `http4s`: `0.23.30` -> `0.23.33`
  - `commons-io`: `2.20.0` -> `2.21.0`
  - `sbt-scalafmt`: `2.5.5` -> `2.5.6`
  - `sbt-scalafix`: `0.14.3` -> `0.14.5`
