### PR TITLE
Remove JVM options from sbt-build.sh as it's now from the env var

### DIFF
--- a/.github/workflows/sbt-build.sh
+++ b/.github/workflows/sbt-build.sh
@@ -24,8 +24,6 @@ then
 #      packagedArtifacts
 #  else
     sbt \
-      -J-XX:MaxMetaspaceSize=1024m \
-      -J-Xmx2048m \
       clean \
       test \
       packagedArtifacts
@@ -44,8 +42,6 @@ else
 #      package
 #  else
     sbt \
-      -J-XX:MaxMetaspaceSize=1024m \
-      -J-Xmx2048m \
       clean \
       test \
       package


### PR DESCRIPTION
Remove JVM options from sbt-build.sh as it's now from the env var