### PR TITLE
Update sbt plugins and GitHub Actions

### DIFF
--- a/.github/workflows/doc-site-build-only.yml
+++ b/.github/workflows/doc-site-build-only.yml
@@ -21,7 +21,7 @@ jobs:
         scala:
           - { binary-version: "2.12", java-version: "11", java-distribution: "temurin" }
         node:
-          - { version: "22.19.0" }
+          - { version: "24.12.0" }
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/doc-site-publish.yml
+++ b/.github/workflows/doc-site-publish.yml
@@ -20,7 +20,7 @@ jobs:
         scala:
           - { binary-version: "2.12", java-version: "11", java-distribution: "temurin" }
         node:
-          - { version: "22.19.0" }
+          - { version: "24.12.0" }
 
     steps:
       - uses: actions/checkout@v6
@@ -59,7 +59,9 @@ jobs:
           echo " JVM_OPTS=${JVM_OPTS}"
           echo " SBT_OPTS=${SBT_OPTS}"
           
-          sbt clean \
+          sbt \
+            gitHubPagesCreateGitHubPagesBranchIfNotExist \
+            clean \
             writeCurrentVersion \
             docusaurGenerateAlgoliaConfigFile \
             docusaurGenerateGoogleAnalyticsConfigFile \

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -10,9 +10,9 @@ addSbtPlugin("com.github.cb372" % "sbt-explicit-dependencies" % "0.3.1")
 
 addSbtPlugin("com.github.reibitto" % "sbt-welcome" % "0.5.0")
 
-addSbtPlugin("io.kevinlee" % "sbt-docusaur" % "0.18.0")
+addSbtPlugin("io.kevinlee" % "sbt-docusaur" % "0.20.0")
 
-val sbtDevOopsVersion = "3.3.1"
+val sbtDevOopsVersion = "3.3.2"
 addSbtPlugin("io.kevinlee" % "sbt-devoops-scala"     % sbtDevOopsVersion)
 addSbtPlugin("io.kevinlee" % "sbt-devoops-sbt-extra" % sbtDevOopsVersion)
 addSbtPlugin("io.kevinlee" % "sbt-devoops-github"    % sbtDevOopsVersion)


### PR DESCRIPTION
## Update sbt plugins and GitHub Actions

- Update `sbt-docusaur`: `0.18.0` => `0.20.0`
- Update `sbt-devoops`: `3.3.1` => `3.3.2`
- Update `Node.js`: `22.19.0` => `24.12.0` in doc-site workflows
- Add `gitHubPagesCreateGitHubPagesBranchIfNotExist` to `doc-site-publish` workflow