### PR TITLE
sbt-devoops v3.5.1

### DIFF
--- a/changelogs/3.5.1.md
+++ b/changelogs/3.5.1.md
@@ -1,0 +1,11 @@
+## [3.5.1](https://github.com/Kevin-Lee/sbt-devoops/issues?q=is%3Aissue%20is%3Aclosed%20-label%3Adeclined%20milestone%3Am44) - 2026-03-23
+
+### Internal Housekeeping
+
+* Update library and sbt plugin versions (#511)
+  * `cats-effect`: `3.6.3` => `3.7.0`
+  * `extras`: `0.50.1` => `0.51.0`
+  * `logger-f`: `2.8.1` => `2.9.0`
+  * `just-semver`: `1.1.1` => `1.2.0`
+  * `sbt-tpolecat`: `0.5.2` => `0.5.3`
+  * `sbt-scalafix`: `0.14.5` => `0.14.6`


### PR DESCRIPTION
# sbt-devoops v3.5.1
## [3.5.1](https://github.com/Kevin-Lee/sbt-devoops/issues?q=is%3Aissue%20is%3Aclosed%20-label%3Adeclined%20milestone%3Am44) - 2026-03-23

### Internal Housekeeping

* Update library and sbt plugin versions (#511)
  * `cats-effect`: `3.6.3` => `3.7.0`
  * `extras`: `0.50.1` => `0.51.0`
  * `logger-f`: `2.8.1` => `2.9.0`
  * `just-semver`: `1.1.1` => `1.2.0`
  * `sbt-tpolecat`: `0.5.2` => `0.5.3`
  * `sbt-scalafix`: `0.14.5` => `0.14.6`
