### PR TITLE
Update library, sbt plugin, and sbt versions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -203,43 +203,43 @@ lazy val props =
 
     val CrossSbtVersions = List(GlobalSbtVersion).distinct
 
-    val hedgehogVersion = "0.13.0"
+    val hedgehogVersion = "0.13.1"
 
     val newtypeVersion = "0.4.4"
 
     val catsVersion       = "2.13.0"
     val catsEffectVersion = "3.7.0"
 
-    val extrasVersion = "0.51.0"
+    val extrasVersion = "0.53.0"
 
     val effectieVersion = "2.3.0"
-    val loggerFVersion  = "2.9.0"
+    val loggerFVersion  = "2.10.0"
 
     val refinedVersion = "0.11.3"
 
     val circeVersion        = "0.14.15"
     val circeRefinedVersion = "0.15.1"
 
-    val http4sVersion = "0.23.33"
+    val http4sVersion = "0.23.34"
 
-    val justSemVerVersion = "1.2.0"
+    val justSemVerVersion = "1.3.0"
 
     val justSysprocessVersion = "1.0.0"
 
-    val commonsIoVersion = "2.21.0"
+    val commonsIoVersion = "2.22.0"
 
     val activationVersion    = "1.1.1"
     val activationApiVersion = "1.2.0"
 
-    val SbtTpolecatVersion = "0.5.3"
+    val SbtTpolecatVersion = "0.5.6"
 
     val SbtVersionPolicyVersion = "3.2.1"
-    val SbtReleaseVersion       = "1.4.0"
+    val SbtReleaseVersion       = "1.5.0"
 
-    val SbtScalafmtVersion = "2.5.6"
-    val SbtScalafixVersion = "0.14.6"
+    val SbtScalafmtVersion = "2.6.1"
+    val SbtScalafixVersion = "0.14.7"
 
-    val SbtWelcomeVersion = "0.5.0"
+    val SbtWelcomeVersion = "0.6.0"
 
     val IncludeTest = "compile->compile;test->test"
   }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.11.7
+sbt.version=1.12.13

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,17 +2,17 @@ logLevel := sbt.Level.Warn
 
 addSbtPlugin("com.github.sbt"   % "sbt-ci-release"            % "1.11.2")
 addSbtPlugin("org.wartremover"  % "sbt-wartremover"           % "3.1.3")
-addSbtPlugin("org.scoverage"    % "sbt-scoverage"             % "2.3.1")
+addSbtPlugin("org.scoverage"    % "sbt-scoverage"             % "2.4.4")
 addSbtPlugin("org.scoverage"    % "sbt-coveralls"             % "1.3.15")
 addSbtPlugin("org.lyranthe.sbt" % "partial-unification"       % "1.1.2")
-addSbtPlugin("com.timushev.sbt" % "sbt-updates"               % "0.6.3")
+addSbtPlugin("com.timushev.sbt" % "sbt-updates"               % "0.7.0")
 addSbtPlugin("com.github.cb372" % "sbt-explicit-dependencies" % "0.3.1")
 
-addSbtPlugin("com.github.reibitto" % "sbt-welcome" % "0.5.0")
+addSbtPlugin("com.github.reibitto" % "sbt-welcome" % "0.6.0")
 
-addSbtPlugin("io.kevinlee" % "sbt-docusaur" % "0.20.0")
+addSbtPlugin("io.kevinlee" % "sbt-docusaur" % "0.21.0")
 
-val sbtDevOopsVersion = "3.3.2"
+val sbtDevOopsVersion = "3.5.1"
 addSbtPlugin("io.kevinlee" % "sbt-devoops-scala"     % sbtDevOopsVersion)
 addSbtPlugin("io.kevinlee" % "sbt-devoops-sbt-extra" % sbtDevOopsVersion)
 addSbtPlugin("io.kevinlee" % "sbt-devoops-github"    % sbtDevOopsVersion)


### PR DESCRIPTION
## Update library, sbt plugin, and sbt versions
- `sbt`: `1.11.7` => `1.12.13`
- `hedgehog`: `0.13.0` => `0.13.1`
- `extras`: `0.51.0` => `0.53.0`
- `logger-f`: `2.9.0` => `2.10.0`
- `http4s`: `0.23.33` => `0.23.34`
- `just-semver`: `1.2.0` => `1.3.0`
- `commons-io`: `2.21.0` => `2.22.0`
- `sbt-tpolecat`: `0.5.3` => `0.5.6`
- `sbt-release`: `1.4.0` => `1.5.0`
- `sbt-scalafmt`: `2.5.6` => `2.6.1`
- `sbt-scalafix`: `0.14.6` => `0.14.7`
- `sbt-welcome`: `0.5.0` => `0.6.0`
- `sbt-scoverage`: `2.3.1` => `2.4.4`
- `sbt-updates`: `0.6.3` => `0.7.0`
- `sbt-docusaur`: `0.20.0` => `0.21.0`
- `sbt-devoops`: `3.3.2` => `3.5.1`
