### PR TITLE
sbt-devoops v3.6.0

### DIFF
--- a/changelogs/3.6.0.md
+++ b/changelogs/3.6.0.md
@@ -1,0 +1,6 @@
+## [3.6.0](https://github.com/kevin-lee/sbt-devoops/issues?q=is%3Aissue%20is%3Aclosed%20-label%3Adeclined%20milestone%3Am45) - 2026-07-06
+
+### New Features
+
+* Add sbt 2 support (#515)
+  * It supports both sbt 1 and sbt 2 now.


### PR DESCRIPTION
# sbt-devoops v3.6.0
## [3.6.0](https://github.com/kevin-lee/sbt-devoops/issues?q=is%3Aissue%20is%3Aclosed%20-label%3Adeclined%20milestone%3Am45) - 2026-07-06

### New Features

* Add sbt 2 support (#515)
  * It supports both sbt 1 and sbt 2 now.
