### PR TITLE
Fix sbt command argument grouping in `release.yml`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -162,13 +162,19 @@ jobs:
           echo '[GPG] import secret key (same as sbt-ci-release setupGpg)'
           echo "$PGP_SECRET" | base64 --decode | gpg --batch --import
 
+          # Note: "++${v} publishSigned" must stay a single sbt command. In that form sbt
+          # runs the task only on subprojects whose crossScalaVersions contains ${v}, which
+          # keeps the Scala-2.12-pinned root out of the sbt 2 / Scala 3 axis (an aggregated
+          # publishSigned there resolves the root's inter-project deps with a malformed
+          # _sbt2_2.12 suffix — see the same note in sbt-build.sh). As two separate
+          # commands ("++${v}" publishSigned) the task would run on the whole aggregate.
           echo '[Java 11] publishSigned for the sbt 1 / Scala 2.x axis'
           export JAVA_HOME="$JAVA_HOME_11_X64"
           export PATH="$JAVA_HOME_11_X64/bin:$PATH"
           java -version
           args=(clean)
           while IFS= read -r v; do
-            args+=("++${v}" publishSigned)
+            args+=("++${v} publishSigned")
           done < <(jq -r '.[]' <<< "$JAVA11_VERSIONS_JSON")
           sbt -v "${args[@]}"
 
@@ -178,7 +184,7 @@ jobs:
           java -version
           args=()
           while IFS= read -r v; do
-            args+=("++${v}" publishSigned)
+            args+=("++${v} publishSigned")
           done < <(jq -r '.[]' <<< "$JAVA17_VERSIONS_JSON")
           sbt -v "${args[@]}"
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,7 @@
 logLevel := sbt.Level.Warn
 
+addSbtPlugin("com.eed3si9n" % "sbt-salad-days" % "0.2.0")
+
 addSbtPlugin("com.github.sbt"   % "sbt-ci-release"            % "1.11.2")
 addSbtPlugin("org.scoverage"    % "sbt-scoverage"             % "2.4.4")
 addSbtPlugin("org.scoverage"    % "sbt-coveralls"             % "1.3.15")


### PR DESCRIPTION
## Fix sbt command argument grouping in `release.yml`

Combined `++${v}` and `publishSigned` into a single sbt command argument. This ensures that sbt runs the task only on subprojects where `crossScalaVersions` contains the target version, preventing the task from running on the whole aggregate and avoiding issues with the Scala-2.12-pinned root on the sbt 2 / Scala 3 axis.