### PR TITLE
Close #523: Add `sbt-devoops-sbt-local-cache` for a build-local sbt 2 cache with flag-controlled cleaning

### DIFF
--- a/.github/workflows/sbt-scripted.sh
+++ b/.github/workflows/sbt-scripted.sh
@@ -31,7 +31,8 @@ if [ "$sbt_series" == "sbt2" ]; then
     -v \
     clean \
     "scala/scripted sbt-devoops-scala/scala-3-sbt2-test" \
-    "starter/scripted sbt-devoops-starter/write-default-scalafmt-conf-sbt2-test-new sbt-devoops-starter/write-default-scalafix-conf-scala3-sbt2-test-new"
+    "starter/scripted sbt-devoops-starter/write-default-scalafmt-conf-sbt2-test-new sbt-devoops-starter/write-default-scalafix-conf-scala3-sbt2-test-new" \
+    "sbt-local-cache/scripted sbt-devoops-sbt-local-cache/sbt2-local-cache sbt-devoops-sbt-local-cache/sbt2-clean-includes-cache sbt-devoops-sbt-local-cache/sbt2-default-off"
 else
   # sbt 1: run the full scripted suite. The sbt-2-pinned tests (sbt.version=2.0.1) are
   # automatically skipped by the scripted runner because their binary sbt version differs

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ lib_managed/
 src_managed/
 project/boot/
 project/plugins/project/
+.sbt-local-cache/
 
 .history
 .cache

--- a/build.sbt
+++ b/build.sbt
@@ -65,6 +65,7 @@ lazy val sbtDevOops = Project(props.ProjectName, file("."))
     sbtDevOopsCommon,
     sbtDevOopsScala,
     sbtDevOopsSbtExtra,
+    sbtDevOopsSbtLocalCache,
     sbtDevOopsHttpCore,
     sbtDevOopsGitHubCore,
     sbtDevOopsStarter,
@@ -96,6 +97,12 @@ lazy val sbtDevOopsScala = subProject(props.SubProjectNameScala)
   .dependsOn(sbtDevOopsCommon)
 
 lazy val sbtDevOopsSbtExtra = subProject(props.SubProjectNameSbtExtra)
+  .enablePlugins(SbtPlugin)
+  .settings(
+    addSbtPlugin(libs.sbt2Compat)
+  )
+
+lazy val sbtDevOopsSbtLocalCache = subProject(props.SubProjectNameSbtLocalCache)
   .enablePlugins(SbtPlugin)
   .settings(
     addSbtPlugin(libs.sbt2Compat)
@@ -249,6 +256,7 @@ lazy val props =
     val SubProjectNameCommon               = "common"
     val SubProjectNameScala                = "scala"
     val SubProjectNameSbtExtra             = "sbt-extra"
+    val SubProjectNameSbtLocalCache        = "sbt-local-cache"
     val SubProjectNameStarter              = "starter"
     val SubProjectNameHttpCore             = "http-core"
     val SubProjectNameGitHubCore           = "github-core"

--- a/modules/sbt-devoops-sbt-local-cache/src/main/scala-2/devoops/DevOopsSbtLocalCacheCompat.scala
+++ b/modules/sbt-devoops-sbt-local-cache/src/main/scala-2/devoops/DevOopsSbtLocalCacheCompat.scala
@@ -1,0 +1,53 @@
+package devoops
+
+import sbt._
+import sbt.Keys._
+import sbtcompat.PluginCompat._
+
+/** sbt 1 (no-op) implementation of the build-local cache support.
+  *
+  * sbt 1 has no machine-wide task result cache, so there is nothing to redirect or remove. Every
+  * member here exists only so that the plugin can be built from the same sources for sbt 1 and sbt
+  * 2.
+  *
+  * @author Kevin Lee
+  * @since 2026-07-15
+  */
+private[devoops] object DevOopsSbtLocalCacheCompat {
+
+  val CleanLocalCacheCommandName: String = "devOopsCleanLocalCache"
+
+  private val Sbt2OnlyMessage: String =
+    "The build-local cache feature is for sbt 2 only, and it does nothing on sbt 1 which has no machine-wide task cache."
+
+  def buildLocalCacheRedirectSettings(
+    useLocalCache: SettingKey[Boolean],
+    cacheDir: SettingKey[File],
+  ): Seq[Def.Setting[_]] = {
+    val _ = (useLocalCache, cacheDir)
+    Seq.empty
+  }
+
+  def cleanLocalCacheCommand: Command =
+    Command.command(
+      CleanLocalCacheCommandName,
+      "Remove the build-local sbt 2 cache.",
+      "Remove the build-local sbt 2 cache directory (sbt 2 only). It does nothing on sbt 1.",
+    ) { state =>
+      state.log.warn(Sbt2OnlyMessage)
+      state
+    }
+
+  def localCacheSizeSettings(key: TaskKey[Long]): Seq[Def.Setting[_]] = Seq(
+    Global / key := Def.uncached {
+      streams.value.log.warn(Sbt2OnlyMessage)
+      0L
+    }
+  )
+
+  def cleanIncludesLocalCacheSettings(flag: SettingKey[Boolean]): Seq[Def.Setting[_]] = {
+    val _ = flag
+    Seq.empty
+  }
+
+}

--- a/modules/sbt-devoops-sbt-local-cache/src/main/scala-3/devoops/DevOopsSbtLocalCacheCompat.scala
+++ b/modules/sbt-devoops-sbt-local-cache/src/main/scala-3/devoops/DevOopsSbtLocalCacheCompat.scala
@@ -1,0 +1,153 @@
+package devoops
+
+import sbt.*
+import sbt.Keys.*
+import sbt.internal.RemoteCache
+import sbtcompat.PluginCompat.*
+
+/** sbt 2 implementation of the build-local cache support.
+  *
+  * sbt 2 caches every task result in a machine-wide, content-addressed disk cache (e.g.
+  * `~/Library/Caches/sbt/v2` on macOS) which `clean` does not touch. This object provides a way to
+  * redirect that cache into the build itself so that it can be removed without affecting any other
+  * project on the machine.
+  *
+  * @author Kevin Lee
+  * @since 2026-07-15
+  */
+private[devoops] object DevOopsSbtLocalCacheCompat {
+
+  val CleanLocalCacheCommandName: String = "devOopsCleanLocalCache"
+
+  private val cacheDeletionLock: AnyRef = new AnyRef
+
+  /** The cache directory is only safe to delete when it lives inside the build. Deleting the
+    * machine-wide cache would affect every other project on the machine, which is exactly what this
+    * feature is meant to avoid.
+    */
+  private def isBuildLocal(cacheDir: File, baseDir: File): Boolean =
+    cacheDir.getAbsoluteFile.toPath.normalize.startsWith(baseDir.getAbsoluteFile.toPath.normalize)
+
+  private def humanReadableSize(bytes: Long): String = {
+    val kib = 1024d
+    val mib = kib * 1024d
+    val gib = mib * 1024d
+    if (bytes >= gib) f"${bytes / gib}%.1f GiB"
+    else if (bytes >= mib) f"${bytes / mib}%.1f MiB"
+    else if (bytes >= kib) f"${bytes / kib}%.1f KiB"
+    else s"$bytes B"
+  }
+
+  private def totalSizeOf(dir: File): Long =
+    if (dir.exists) (dir.allPaths --- dir.allPaths.filter(_.isDirectory)).get().map(_.length()).sum
+    else 0L
+
+  /** The sbt 2 shell command history, written to `<rootOutputDirectory>/.history`. It lives inside
+    * the output directory but is not cache content, so it must survive a cache purge.
+    */
+  private def historyFileName: String = ".history"
+
+  /** Deletes the build-local cache directory and the contents of the sbt 2 root output directory,
+    * then recreates the empty `cas` and `ac` directories so the `DiskActionCacheStore` of the running
+    * session keeps working.
+    *
+    * The shell command history (`<outDir>/.history`) is preserved since it is not cache content.
+    */
+  private def deleteBuildLocalCache(cacheDir: File, outDir: File): Unit =
+    cacheDeletionLock.synchronized {
+      IO.delete(cacheDir)
+      deleteOutputDirKeepingHistory(outDir)
+      IO.createDirectory(cacheDir / "cas")
+      IO.createDirectory(cacheDir / "ac")
+    }
+
+  /** Deletes everything under `outDir` except the shell command history file, so removing the cache
+    * does not wipe the user's command history.
+    *
+    * The history file is a direct child of `outDir` (`<outDir>/.history`), so only the top level
+    * needs filtering: every other child is deleted wholesale and the history file itself is never
+    * touched. Unlike a backup-and-restore, there is no window where the history exists only in
+    * memory, and `outDir` itself is kept.
+    */
+  private def deleteOutputDirKeepingHistory(outDir: File): Unit =
+    Option(outDir.listFiles).foreach { files =>
+      IO.delete(files.filter(_.getName != historyFileName).toSeq)
+    }
+
+  private def notBuildLocalWarning(cacheDir: File, baseDir: File): String =
+    s"""The sbt local cache is not build-local so it was not removed.
+       |  cache directory: ${cacheDir.getAbsolutePath}
+       |  build directory: ${baseDir.getAbsolutePath}
+       |This cache is shared with all the other builds on this machine, so removing it would affect them.
+       |To make it build-local, set `Global / devOopsUseLocalCache := true` in build.sbt.
+       |To remove the machine-wide cache instead, use sbt's built-in `cleanFull` command.""".stripMargin
+
+  /** When `useLocalCache` is `false`, this resolves to `RemoteCache.defaultCacheLocation`, the exact
+    * value sbt 2 itself assigns to `localCacheDirectory`, so it is equivalent to leaving the setting
+    * untouched.
+    */
+  def buildLocalCacheRedirectSettings(
+    useLocalCache: SettingKey[Boolean],
+    cacheDir: SettingKey[File],
+  ): Seq[Def.Setting[_]] = Seq(
+    Global / localCacheDirectory := {
+      if ((Global / useLocalCache).value) (Global / cacheDir).value
+      else RemoteCache.defaultCacheLocation
+    }
+  )
+
+  def cleanLocalCacheCommand: Command =
+    Command.command(
+      CleanLocalCacheCommandName,
+      "Remove the build-local sbt 2 cache.",
+      "Remove the build-local sbt 2 cache directory (sbt 2 only). " +
+        "It does nothing if the cache is not build-local (i.e. `devOopsUseLocalCache` is not `true`).",
+    ) { state =>
+      val extracted = Project.extract(state)
+      val cacheDir  = extracted.get(Global / localCacheDirectory)
+      val baseDir   = extracted.get(ThisBuild / baseDirectory)
+      val outDir    = extracted.get(Global / rootOutputDirectory).toFile
+      val log       = state.log
+      if (isBuildLocal(cacheDir, baseDir)) {
+        deleteBuildLocalCache(cacheDir, outDir)
+        log.info(s"The build-local sbt cache has been removed. (${cacheDir.getAbsolutePath})")
+        "clearCaches" :: state
+      } else {
+        log.warn(notBuildLocalWarning(cacheDir, baseDir))
+        state
+      }
+    }
+
+  def localCacheSizeSettings(key: TaskKey[Long]): Seq[Def.Setting[_]] = Seq(
+    Global / key := Def.uncached {
+      val cacheDir = (Global / localCacheDirectory).value
+      val size     = totalSizeOf(cacheDir)
+      streams.value.log.info(s"sbt local cache: ${cacheDir.getAbsolutePath} (${humanReadableSize(size)})")
+      size
+    }
+  )
+
+  private def purgeBuildLocalCacheTask: Def.Initialize[Task[Unit]] = Def.task {
+    val cacheDir = (Global / localCacheDirectory).value
+    val baseDir  = (ThisBuild / baseDirectory).value
+    val outDir   = (Global / rootOutputDirectory).value.toFile
+    val log      = streams.value.log
+    if (isBuildLocal(cacheDir, baseDir)) {
+      deleteBuildLocalCache(cacheDir, outDir)
+      log.info(s"The build-local sbt cache has been removed. (${cacheDir.getAbsolutePath})")
+    } else {
+      log.warn(notBuildLocalWarning(cacheDir, baseDir))
+    }
+  }
+
+  def cleanIncludesLocalCacheSettings(flag: SettingKey[Boolean]): Seq[Def.Setting[_]] = Seq(
+    clean := Def.uncached {
+      Def.taskDyn {
+        val cleaned = clean.value
+        if ((Global / flag).value) Def.task { purgeBuildLocalCacheTask.value; cleaned }
+        else Def.task(cleaned)
+      }.value
+    }
+  )
+
+}

--- a/modules/sbt-devoops-sbt-local-cache/src/main/scala/devoops/DevOopsSbtLocalCachePlugin.scala
+++ b/modules/sbt-devoops-sbt-local-cache/src/main/scala/devoops/DevOopsSbtLocalCachePlugin.scala
@@ -1,0 +1,52 @@
+package devoops
+
+import sbt.{Def, *}
+
+/** @author Kevin Lee
+  * @since 2026-07-15
+  */
+object DevOopsSbtLocalCachePlugin extends AutoPlugin {
+
+  override def requires: Plugins      = plugins.JvmPlugin
+  override def trigger: PluginTrigger = allRequirements
+
+  object autoImport {
+
+    val devOopsBuildLocalCacheDirectory: SettingKey[File] = settingKey[File](
+      "sbt 2 only: The build-local sbt cache directory used when devOopsUseLocalCache is true. " +
+        "(default: <build root>/.sbt-local-cache)"
+    )
+
+    val devOopsUseLocalCache: SettingKey[Boolean] = settingKey[Boolean](
+      "sbt 2 only: If true, use a build-local sbt cache (devOopsBuildLocalCacheDirectory) instead of the machine-wide one. " +
+        "Set it at the Global scope: Global / devOopsUseLocalCache := true (default: false)"
+    )
+
+    val devOopsCleanIncludesLocalCache: SettingKey[Boolean] = settingKey[Boolean](
+      "sbt 2 only: If true, `clean` also removes the build-local cache in every project. " +
+        "It has no effect when the cache is not build-local. (default: false)"
+    )
+
+    val devOopsLocalCacheSize: TaskKey[Long] = taskKey[Long](
+      "sbt 2 only: Show the location and the total size of the sbt local cache in use, and return the size in bytes."
+    )
+  }
+
+  import autoImport.*
+
+  override def globalSettings: Seq[Def.Setting[_]] = Seq(
+    devOopsBuildLocalCacheDirectory := (ThisBuild / Keys.baseDirectory).value / ".sbt-local-cache",
+    devOopsUseLocalCache := false,
+    devOopsCleanIncludesLocalCache := false,
+    Keys.commands += DevOopsSbtLocalCacheCompat.cleanLocalCacheCommand,
+  ) ++ DevOopsSbtLocalCacheCompat.localCacheSizeSettings(devOopsLocalCacheSize) ++
+    DevOopsSbtLocalCacheCompat.buildLocalCacheRedirectSettings(devOopsUseLocalCache, devOopsBuildLocalCacheDirectory)
+
+  /** Because this plugin `requires = plugins.JvmPlugin`, `Plugins.topologicalSort` orders these
+    * `projectSettings` AFTER `JvmPlugin.projectSettings` (which defines sbt's default `clean`), so
+    * this override wins in every project without needing an explicit `.settings(...)` add.
+    */
+  override def projectSettings: Seq[Def.Setting[_]] =
+    DevOopsSbtLocalCacheCompat.cleanIncludesLocalCacheSettings(devOopsCleanIncludesLocalCache)
+
+}

--- a/modules/sbt-devoops-sbt-local-cache/src/sbt-test/sbt-devoops-sbt-local-cache/sbt1-noop/build.sbt
+++ b/modules/sbt-devoops-sbt-local-cache/src/sbt-test/sbt-devoops-sbt-local-cache/sbt1-noop/build.sbt
@@ -1,0 +1,11 @@
+ThisBuild / scalaVersion     := "2.12.18"
+ThisBuild / version          := "0.1.0-SNAPSHOT"
+ThisBuild / organization     := "com.example"
+ThisBuild / organizationName := "example"
+
+Global / devOopsUseLocalCache := true
+
+lazy val root = (project in file("."))
+  .settings(
+    name := "sbt1-noop"
+  )

--- a/modules/sbt-devoops-sbt-local-cache/src/sbt-test/sbt-devoops-sbt-local-cache/sbt1-noop/project/build.properties
+++ b/modules/sbt-devoops-sbt-local-cache/src/sbt-test/sbt-devoops-sbt-local-cache/sbt1-noop/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.11.7

--- a/modules/sbt-devoops-sbt-local-cache/src/sbt-test/sbt-devoops-sbt-local-cache/sbt1-noop/project/plugins.sbt
+++ b/modules/sbt-devoops-sbt-local-cache/src/sbt-test/sbt-devoops-sbt-local-cache/sbt1-noop/project/plugins.sbt
@@ -1,0 +1,5 @@
+sys.props.get("plugin.version") match {
+  case Some(x) => addSbtPlugin("io.kevinlee" % "sbt-devoops-sbt-local-cache" % x)
+  case _ => sys.error("""|The system property 'plugin.version' is not defined.
+                         |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+}

--- a/modules/sbt-devoops-sbt-local-cache/src/sbt-test/sbt-devoops-sbt-local-cache/sbt1-noop/src/main/scala/example/Hello.scala
+++ b/modules/sbt-devoops-sbt-local-cache/src/sbt-test/sbt-devoops-sbt-local-cache/sbt1-noop/src/main/scala/example/Hello.scala
@@ -1,0 +1,9 @@
+package example
+
+object Hello extends Greeting with App {
+  println(greeting)
+}
+
+trait Greeting {
+  lazy val greeting: String = "hello"
+}

--- a/modules/sbt-devoops-sbt-local-cache/src/sbt-test/sbt-devoops-sbt-local-cache/sbt1-noop/test
+++ b/modules/sbt-devoops-sbt-local-cache/src/sbt-test/sbt-devoops-sbt-local-cache/sbt1-noop/test
@@ -1,0 +1,5 @@
+> compile
+> devOopsCleanLocalCache
+> devOopsLocalCacheSize
+> clean
+> compile

--- a/modules/sbt-devoops-sbt-local-cache/src/sbt-test/sbt-devoops-sbt-local-cache/sbt2-clean-includes-cache/build.sbt
+++ b/modules/sbt-devoops-sbt-local-cache/src/sbt-test/sbt-devoops-sbt-local-cache/sbt2-clean-includes-cache/build.sbt
@@ -1,0 +1,61 @@
+ThisBuild / scalaVersion     := "3.3.5"
+ThisBuild / version          := "0.1.0-SNAPSHOT"
+ThisBuild / organization     := "com.example"
+ThisBuild / organizationName := "example"
+
+Global / devOopsUseLocalCache := true
+
+Global / devOopsCleanIncludesLocalCache := true
+
+lazy val checkCacheNonEmpty = taskKey[Unit]("Check the build-local cache has the cached content.")
+lazy val checkCachePurged   = taskKey[Unit]("Check the build-local cache has no cached content.")
+lazy val writeHistory       = taskKey[Unit]("Write a sentinel shell history file into the output directory.")
+lazy val checkHistoryKept   = taskKey[Unit]("Check the sentinel shell history file survived the cache purge.")
+
+// The sbt 2 shell command history lives at `<rootOutputDirectory>/.history`, inside the output
+// directory that a cache purge deletes. Purging the cache must not wipe it.
+lazy val HistoryContent = "1700000000000:compile\n1700000000001:test\n"
+
+// `clean` re-caches its own result after removing the cache, so a few entries for `clean` itself
+// may remain. It is only the cached content of the actual work (e.g. compile) which must be gone.
+lazy val MaxFilesWhenPurged = 3
+
+lazy val root = (project in file("."))
+  .settings(
+    name := "sbt2-clean-includes-cache",
+    checkCacheNonEmpty := Def.uncached {
+      val dir   = (Global / devOopsBuildLocalCacheDirectory).value
+      val files = (dir.allPaths --- dir.allPaths.filter(_.isDirectory)).get()
+      if (files.length <= MaxFilesWhenPurged)
+        sys.error(
+          s"The build-local cache is expected to have the cached content but it has only ${files.length} file(s). (${dir.getAbsolutePath})"
+        )
+      else ()
+    },
+    checkCachePurged := Def.uncached {
+      val dir   = (Global / devOopsBuildLocalCacheDirectory).value
+      val files = (dir.allPaths --- dir.allPaths.filter(_.isDirectory)).get()
+      if (files.length > MaxFilesWhenPurged)
+        sys.error(
+          s"The build-local cache is expected to be purged but it still has ${files.length} file(s). (${dir.getAbsolutePath})"
+        )
+      else ()
+    },
+    writeHistory := Def.uncached {
+      val history = (Global / rootOutputDirectory).value.toFile / ".history"
+      IO.write(history, HistoryContent)
+    },
+    checkHistoryKept := Def.uncached {
+      val history = (Global / rootOutputDirectory).value.toFile / ".history"
+      if (!history.isFile)
+        sys.error(s"The shell history was removed by the cache purge. (${history.getAbsolutePath})")
+      else {
+        val actual = IO.read(history)
+        if (actual != HistoryContent)
+          sys.error(
+            s"The shell history content was changed by the cache purge. (${history.getAbsolutePath})\nexpected: $HistoryContent\nactual:   $actual"
+          )
+        else ()
+      }
+    },
+  )

--- a/modules/sbt-devoops-sbt-local-cache/src/sbt-test/sbt-devoops-sbt-local-cache/sbt2-clean-includes-cache/project/build.properties
+++ b/modules/sbt-devoops-sbt-local-cache/src/sbt-test/sbt-devoops-sbt-local-cache/sbt2-clean-includes-cache/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=2.0.1

--- a/modules/sbt-devoops-sbt-local-cache/src/sbt-test/sbt-devoops-sbt-local-cache/sbt2-clean-includes-cache/project/plugins.sbt
+++ b/modules/sbt-devoops-sbt-local-cache/src/sbt-test/sbt-devoops-sbt-local-cache/sbt2-clean-includes-cache/project/plugins.sbt
@@ -1,0 +1,5 @@
+sys.props.get("plugin.version") match {
+  case Some(x) => addSbtPlugin("io.kevinlee" % "sbt-devoops-sbt-local-cache" % x)
+  case _ => sys.error("""|The system property 'plugin.version' is not defined.
+                         |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+}

--- a/modules/sbt-devoops-sbt-local-cache/src/sbt-test/sbt-devoops-sbt-local-cache/sbt2-clean-includes-cache/src/main/scala/example/Hello.scala
+++ b/modules/sbt-devoops-sbt-local-cache/src/sbt-test/sbt-devoops-sbt-local-cache/sbt2-clean-includes-cache/src/main/scala/example/Hello.scala
@@ -1,0 +1,9 @@
+package example
+
+object Hello extends Greeting {
+  @main def run(): Unit = println(greeting)
+}
+
+trait Greeting {
+  lazy val greeting: String = "hello"
+}

--- a/modules/sbt-devoops-sbt-local-cache/src/sbt-test/sbt-devoops-sbt-local-cache/sbt2-clean-includes-cache/test
+++ b/modules/sbt-devoops-sbt-local-cache/src/sbt-test/sbt-devoops-sbt-local-cache/sbt2-clean-includes-cache/test
@@ -1,0 +1,20 @@
+> compile
+> checkCacheNonEmpty
+# The shell history lives inside the output directory that a purge deletes; it must survive.
+> writeHistory
+> clean
+> checkCachePurged
+> checkHistoryKept
+> compile
+> checkCacheNonEmpty
+# A second clean must also purge. If the purge were cached (memoized), the second
+# clean would restore the cached no-op result and skip the purge, leaving the cache.
+> clean
+> checkCachePurged
+# The devOopsCleanLocalCache command must also purge the cache while keeping the history.
+> compile
+> checkCacheNonEmpty
+> writeHistory
+> devOopsCleanLocalCache
+> checkCachePurged
+> checkHistoryKept

--- a/modules/sbt-devoops-sbt-local-cache/src/sbt-test/sbt-devoops-sbt-local-cache/sbt2-default-off/build.sbt
+++ b/modules/sbt-devoops-sbt-local-cache/src/sbt-test/sbt-devoops-sbt-local-cache/sbt2-default-off/build.sbt
@@ -1,0 +1,27 @@
+ThisBuild / scalaVersion     := "3.3.5"
+ThisBuild / version          := "0.1.0-SNAPSHOT"
+ThisBuild / organization     := "com.example"
+ThisBuild / organizationName := "example"
+
+lazy val checkCacheNotBuildLocal = taskKey[Unit]("Check the sbt local cache is not build-local.")
+
+lazy val root = (project in file("."))
+  .settings(
+    name := "sbt2-default-off",
+    checkCacheNotBuildLocal := Def.uncached {
+      val cacheDir     = (Global / localCacheDirectory).value
+      val baseDir      = (ThisBuild / baseDirectory).value
+      val buildLocalCache = baseDir / ".sbt-local-cache"
+      /* scripted redirects the sbt global base into the test's temp directory,
+       * so the default (machine-wide) cache path can legitimately live under baseDir.
+       * Only the plugin's own build-local path counts as build-local here.
+       */
+      if (cacheDir.getAbsoluteFile.toPath.normalize == buildLocalCache.getAbsoluteFile.toPath.normalize)
+        sys.error(
+          s"The sbt local cache is expected to be machine-wide but it is build-local. (${cacheDir.getAbsolutePath})"
+        )
+      else if (buildLocalCache.exists)
+        sys.error(s"The build-local cache directory is expected not to exist. (${buildLocalCache.getAbsolutePath})")
+      else ()
+    },
+  )

--- a/modules/sbt-devoops-sbt-local-cache/src/sbt-test/sbt-devoops-sbt-local-cache/sbt2-default-off/project/build.properties
+++ b/modules/sbt-devoops-sbt-local-cache/src/sbt-test/sbt-devoops-sbt-local-cache/sbt2-default-off/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=2.0.1

--- a/modules/sbt-devoops-sbt-local-cache/src/sbt-test/sbt-devoops-sbt-local-cache/sbt2-default-off/project/plugins.sbt
+++ b/modules/sbt-devoops-sbt-local-cache/src/sbt-test/sbt-devoops-sbt-local-cache/sbt2-default-off/project/plugins.sbt
@@ -1,0 +1,5 @@
+sys.props.get("plugin.version") match {
+  case Some(x) => addSbtPlugin("io.kevinlee" % "sbt-devoops-sbt-local-cache" % x)
+  case _ => sys.error("""|The system property 'plugin.version' is not defined.
+                         |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+}

--- a/modules/sbt-devoops-sbt-local-cache/src/sbt-test/sbt-devoops-sbt-local-cache/sbt2-default-off/test
+++ b/modules/sbt-devoops-sbt-local-cache/src/sbt-test/sbt-devoops-sbt-local-cache/sbt2-default-off/test
@@ -1,0 +1,3 @@
+> checkCacheNotBuildLocal
+> devOopsCleanLocalCache
+> checkCacheNotBuildLocal

--- a/modules/sbt-devoops-sbt-local-cache/src/sbt-test/sbt-devoops-sbt-local-cache/sbt2-local-cache/build.sbt
+++ b/modules/sbt-devoops-sbt-local-cache/src/sbt-test/sbt-devoops-sbt-local-cache/sbt2-local-cache/build.sbt
@@ -1,0 +1,30 @@
+ThisBuild / scalaVersion     := "3.3.5"
+ThisBuild / version          := "0.1.0-SNAPSHOT"
+ThisBuild / organization     := "com.example"
+ThisBuild / organizationName := "example"
+
+Global / devOopsUseLocalCache := true
+
+lazy val checkCacheNonEmpty = taskKey[Unit]("Check the build-local cache is not empty.")
+lazy val checkCacheEmpty    = taskKey[Unit]("Check the build-local cache has no cached content.")
+
+lazy val root = (project in file("."))
+  .settings(
+    name := "sbt2-local-cache",
+    checkCacheNonEmpty := Def.uncached {
+      val dir   = (Global / devOopsBuildLocalCacheDirectory).value
+      val files = (dir.allPaths --- dir.allPaths.filter(_.isDirectory)).get()
+      if (files.isEmpty)
+        sys.error(s"The build-local cache is expected to be non-empty but it is empty. (${dir.getAbsolutePath})")
+      else ()
+    },
+    checkCacheEmpty := Def.uncached {
+      val dir   = (Global / devOopsBuildLocalCacheDirectory).value
+      val files = (dir.allPaths --- dir.allPaths.filter(_.isDirectory)).get()
+      if (files.nonEmpty)
+        sys.error(
+          s"The build-local cache is expected to be empty but it has ${files.length} file(s). (${dir.getAbsolutePath})"
+        )
+      else ()
+    },
+  )

--- a/modules/sbt-devoops-sbt-local-cache/src/sbt-test/sbt-devoops-sbt-local-cache/sbt2-local-cache/project/build.properties
+++ b/modules/sbt-devoops-sbt-local-cache/src/sbt-test/sbt-devoops-sbt-local-cache/sbt2-local-cache/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=2.0.1

--- a/modules/sbt-devoops-sbt-local-cache/src/sbt-test/sbt-devoops-sbt-local-cache/sbt2-local-cache/project/plugins.sbt
+++ b/modules/sbt-devoops-sbt-local-cache/src/sbt-test/sbt-devoops-sbt-local-cache/sbt2-local-cache/project/plugins.sbt
@@ -1,0 +1,5 @@
+sys.props.get("plugin.version") match {
+  case Some(x) => addSbtPlugin("io.kevinlee" % "sbt-devoops-sbt-local-cache" % x)
+  case _ => sys.error("""|The system property 'plugin.version' is not defined.
+                         |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+}

--- a/modules/sbt-devoops-sbt-local-cache/src/sbt-test/sbt-devoops-sbt-local-cache/sbt2-local-cache/src/main/scala/example/Hello.scala
+++ b/modules/sbt-devoops-sbt-local-cache/src/sbt-test/sbt-devoops-sbt-local-cache/sbt2-local-cache/src/main/scala/example/Hello.scala
@@ -1,0 +1,9 @@
+package example
+
+object Hello extends Greeting {
+  @main def run(): Unit = println(greeting)
+}
+
+trait Greeting {
+  lazy val greeting: String = "hello"
+}

--- a/modules/sbt-devoops-sbt-local-cache/src/sbt-test/sbt-devoops-sbt-local-cache/sbt2-local-cache/test
+++ b/modules/sbt-devoops-sbt-local-cache/src/sbt-test/sbt-devoops-sbt-local-cache/sbt2-local-cache/test
@@ -1,0 +1,9 @@
+> compile
+> checkCacheNonEmpty
+> clean
+> checkCacheNonEmpty
+> devOopsLocalCacheSize
+> devOopsCleanLocalCache
+> checkCacheEmpty
+> compile
+> checkCacheNonEmpty

--- a/website/docs/sbt-local-cache-plugin/_category_.json
+++ b/website/docs/sbt-local-cache-plugin/_category_.json
@@ -1,0 +1,6 @@
+{
+  "label": "DevOopsSbtLocalCachePlugin",
+  "position": 6,
+  "collapsible": true,
+  "collapsed": true
+}

--- a/website/docs/sbt-local-cache-plugin/local-cache.md
+++ b/website/docs/sbt-local-cache-plugin/local-cache.md
@@ -1,0 +1,132 @@
+---
+id: local-cache
+title: "DevOopsSbtLocalCachePlugin - Build-Local Cache (sbt 2)"
+sidebar_label: "Build-Local Cache (sbt 2)"
+---
+
+## Why?
+
+sbt 2 caches the result of every task (e.g. `compile`, `test`) in a **machine-wide** disk cache
+(e.g. `~/Library/Caches/sbt/v2` on macOS). The cache is content-addressed and always on, and it is
+shared with **all the other builds on the machine**.
+
+`clean` only removes `target`, so it does not remove anything from that cache. In other words,
+
+```sbt
+sbt "clean; compile"
+```
+
+is still a cache hit, and the compiled result is simply restored from the machine-wide cache.
+
+sbt itself offers only all-or-nothing solutions.
+
+* `cleanFull` removes the **entire machine-wide** cache, which affects every other build on the machine.
+* `Global / cacheVersion` invalidates the cache, but it never removes the old cached data, so the
+  cache keeps growing.
+
+`DevOopsSbtExtraPlugin` offers a middle ground: make the cache **build-local**, so that it can be
+removed for this build only, without affecting any other project on the machine.
+
+:::note
+This is an **sbt 2 only** feature. On sbt 1, which has no machine-wide task cache, all the settings,
+the task and the command below do nothing.
+:::
+
+## How to Use
+
+Set `devOopsUseLocalCache` to `true` at the `Global` scope in `build.sbt` to opt in.
+
+```sbt
+Global / devOopsUseLocalCache := true
+```
+
+It redirects sbt 2's cache to `devOopsBuildLocalCacheDirectory` which is `.sbt-local-cache` in the
+build root by default. Once it is done, the build no longer shares the machine-wide cache, and the
+cache can be removed with
+
+```sbt
+sbt devOopsCleanLocalCache
+```
+
+which removes the build-local cache directory (as well as `target/out`), so the next `compile` or
+`test` actually runs again.
+
+It is recommended to add the cache directory to `.gitignore`.
+
+```gitignore
+.sbt-local-cache/
+```
+
+## Settings, Task and Command
+
+| Name | Type | Default | Description |
+|---|---|---|---|
+| `devOopsUseLocalCache` | `SettingKey[Boolean]` | `false` | Set to `true` at the `Global` scope to make sbt 2's cache build-local. |
+| `devOopsBuildLocalCacheDirectory` | `SettingKey[File]` | `<build root>/.sbt-local-cache` | The build-local cache directory. |
+| `devOopsCleanIncludesLocalCache` | `SettingKey[Boolean]` | `false` | If `true`, `clean` also removes the build-local cache. |
+| `devOopsLocalCacheSize` | `TaskKey[Long]` | | Show the location and the total size of the sbt local cache in use, and return the size in bytes. |
+| `devOopsCleanLocalCache` | Command | | Remove the build-local cache. |
+
+### `devOopsBuildLocalCacheDirectory`
+
+To use a different directory,
+
+```sbt
+Global / devOopsUseLocalCache := true
+
+Global / devOopsBuildLocalCacheDirectory := (ThisBuild / baseDirectory).value / ".cache" / "sbt"
+```
+
+:::caution
+`devOopsCleanLocalCache` and `devOopsCleanIncludesLocalCache` only remove the cache when it is
+**inside the build**. If the cache directory is outside the build (e.g. the machine-wide cache
+because `devOopsUseLocalCache` is not set to `true`), they log a warning and do nothing, since
+removing it would affect all the other builds on the machine. Use sbt's built-in `cleanFull` if the
+machine-wide cache should really be removed.
+:::
+
+### `devOopsCleanIncludesLocalCache`
+
+By default, `clean` does not remove the build-local cache, so the cache hit is still available after
+`clean`. To make `clean` remove the build-local cache as well, set
+`devOopsCleanIncludesLocalCache` to `true`.
+
+```sbt
+Global / devOopsUseLocalCache := true
+
+Global / devOopsCleanIncludesLocalCache := true
+
+lazy val root = (project in file("."))
+  .settings(
+    name := "my-project"
+  )
+```
+
+With this, `sbt clean` removes both `target` and the build-local cache, so the following `compile`
+or `test` runs again instead of being restored from the cache.
+
+:::note
+`clean` is also a cached task in sbt 2, so the result of `clean` itself is cached again right after
+it has removed the build-local cache. It means a couple of small entries for `clean` may remain in
+the cache directory. It is harmless since the cached content of the actual work (e.g. `compile`,
+`test`) is gone, and the next `compile` or `test` runs again.
+:::
+
+### `devOopsLocalCacheSize`
+
+```sbt
+sbt devOopsLocalCacheSize
+```
+
+```
+[info] sbt local cache: /path/to/project/.sbt-local-cache (123.4 MiB)
+```
+
+## Running Tests Again
+
+If the goal is only to run tests again regardless of the cache, sbt 2 already has `testFull` which
+is never cached.
+
+```sbt
+sbt testFull
+```


### PR DESCRIPTION
# Close #523: Add `sbt-devoops-sbt-local-cache` for a build-local sbt 2 cache with flag-controlled cleaning

sbt 2 caches every task result in an always-on, machine-wide disk cache, so `clean; compile` is still a cache hit, and the only built-in remedies are all-or-nothing: `cleanFull` wipes the cache shared with every other build on the machine, and bumping `cacheVersion` just grows it forever.

The new `sbt-devoops-sbt-local-cache` plugin (sbt 1: no-op) offers a middle ground by redirecting the cache into the build itself so it can be removed for this build only. Everything is applied automatically and controlled by two flags, both `false` by default:

- `Global / devOopsUseLocalCache := true` redirects the cache to `devOopsBuildLocalCacheDirectory` (default: `<build root>/.sbt-local-cache`).
- `Global / devOopsCleanIncludesLocalCache := true` makes `clean` also purge the build-local cache. The override wins over sbt's own `clean` because the plugin requires `JvmPlugin`, ordering its settings after it.

The `devOopsCleanLocalCache` command and `devOopsLocalCacheSize` task are also provided. Destructive operations refuse to touch a cache that is not inside the build, and the shell command history (`target/out/.history`) survives a purge since it is not cache content. Scripted tests cover the redirect, the clean behavior, the default-off case, and the sbt 1 no-op.