### PR TITLE
Close #525: Add `devOopsAlwaysShowOnLoadMessage` to show the welcome message on every sbt 2 interactive start

### DIFF
--- a/.github/workflows/sbt-scripted.sh
+++ b/.github/workflows/sbt-scripted.sh
@@ -32,7 +32,8 @@ if [ "$sbt_series" == "sbt2" ]; then
     clean \
     "scala/scripted sbt-devoops-scala/scala-3-sbt2-test" \
     "starter/scripted sbt-devoops-starter/write-default-scalafmt-conf-sbt2-test-new sbt-devoops-starter/write-default-scalafix-conf-scala3-sbt2-test-new" \
-    "sbt-local-cache/scripted sbt-devoops-sbt-local-cache/sbt2-local-cache sbt-devoops-sbt-local-cache/sbt2-clean-includes-cache sbt-devoops-sbt-local-cache/sbt2-default-off"
+    "sbt-local-cache/scripted sbt-devoops-sbt-local-cache/sbt2-local-cache sbt-devoops-sbt-local-cache/sbt2-clean-includes-cache sbt-devoops-sbt-local-cache/sbt2-default-off" \
+    "sbt-extra/scripted sbt-devoops-sbt-extra/sbt2-always-show-default-off sbt-devoops-sbt-extra/sbt2-always-show-enabled"
 else
   # sbt 1: run the full scripted suite. The sbt-2-pinned tests (sbt.version=2.0.1) are
   # automatically skipped by the scripted runner because their binary sbt version differs

--- a/modules/sbt-devoops-sbt-extra/src/main/scala-2/devoops/DevOopsSbtExtraCompat.scala
+++ b/modules/sbt-devoops-sbt-extra/src/main/scala-2/devoops/DevOopsSbtExtraCompat.scala
@@ -1,0 +1,24 @@
+package devoops
+
+import sbt._
+
+/** sbt 1 (no-op) implementation of "always show the welcome message on an interactive start".
+  *
+  * The problem this feature solves does not exist on sbt 1. sbt 1 has no thin client, so starting
+  * `sbt` always loads the project, which always prints `onLoadMessage`. It is only sbt 2's `sbtn`
+  * client attaching to an already running server that skips the load and so skips the message.
+  *
+  * Every member here exists only so that the plugin can be built from the same sources for sbt 1
+  * and sbt 2. See the scala-3 twin of this object for the real implementation.
+  *
+  * @author Kevin Lee
+  * @since 2026-07-20
+  */
+private[devoops] object DevOopsSbtExtraCompat {
+
+  def alwaysShowOnLoadMessageSettings(flag: SettingKey[Boolean]): Seq[Def.Setting[_]] = {
+    val _ = flag
+    Seq.empty
+  }
+
+}

--- a/modules/sbt-devoops-sbt-extra/src/main/scala-3/devoops/DevOopsSbtExtraCompat.scala
+++ b/modules/sbt-devoops-sbt-extra/src/main/scala-3/devoops/DevOopsSbtExtraCompat.scala
@@ -1,0 +1,78 @@
+package devoops
+
+import sbt.*
+import sbt.Keys.*
+import sbt.devoopsinternal.DevOopsWelcomeInternal
+
+import scala.util.control.NonFatal
+
+/** sbt 2 implementation of "always show the welcome message on an interactive start".
+  *
+  * sbt 2's `sbt` launcher is a thin client. When it attaches to an already running server the
+  * project is not loaded, so sbt never prints `onLoadMessage` and the welcome banner configured by
+  * `sbt-devoops-starter` (logo + useful tasks) disappears. It reappears only after `sbt shutdown`,
+  * which is what makes it look intermittent.
+  *
+  * `onLoad` is applied inside `Project.setProject`, the very same gate as `onLoadMessage`, so it
+  * cannot be used to detect an attach. The only surface that runs on a warm attach is
+  * `colorShellPrompt`, which is why the message is emitted from there, guarded down to once per
+  * attach by [[sbt.devoopsinternal.DevOopsWelcomeInternal]].
+  *
+  * See the scala-2 twin of this object, which is a no-op: sbt 1 has no thin client, so it always
+  * loads the project and always prints the message.
+  *
+  * @author Kevin Lee
+  * @since 2026-07-20
+  */
+private[devoops] object DevOopsSbtExtraCompat {
+
+  /** `colorShellPrompt` is called on every prompt render, and `onLoad` only on an actual project
+    * load. Together they give "print exactly once per interactive start": the `onLoad` hook records
+    * that sbt has just printed the message itself, and the prompt hook prints it only when it finds
+    * that no load did.
+    *
+    * Both settings are installed unconditionally and do nothing when `flag` is `false`, so the
+    * shell prompt is untouched for anyone who has not opted in.
+    */
+  def alwaysShowOnLoadMessageSettings(flag: SettingKey[Boolean]): Seq[Def.Setting[_]] = Seq(
+    Global / onLoad := {
+      val enabled  = (Global / flag).value
+      val previous = (Global / onLoad).value
+      if enabled then {
+        previous.andThen { loadedState =>
+          DevOopsWelcomeInternal.onLoaded()
+          loadedState
+        }
+      } else {
+        previous
+      }
+    },
+    Global / colorShellPrompt := {
+      val enabled          = (Global / flag).value
+      val shellPromptValue = shellPrompt.value
+      (isColorEnabled: Boolean, state: State) => {
+        if enabled then showWelcomeMessageIfNeeded(state) else ()
+        DevOopsWelcomeInternal.renderPrompt(shellPromptValue, isColorEnabled, state)
+      }
+    },
+  )
+
+  private def showWelcomeMessageIfNeeded(state: State): Unit = {
+    val channel = DevOopsWelcomeInternal.currentChannelName()
+    if DevOopsWelcomeInternal.shouldShow(channel) then {
+      onLoadMessageOf(state).foreach { message =>
+        val _ = DevOopsWelcomeInternal.writeTo(channel, message)
+      }
+    } else {
+      ()
+    }
+  }
+
+  /** Reads whatever `onLoadMessage` the build configured, so the message shown on a warm attach is
+    * exactly the one sbt would have shown on a cold start.
+    */
+  private def onLoadMessageOf(state: State): Option[String] =
+    try Project.extract(state).getOpt(Keys.onLoadMessage).filter(_.nonEmpty)
+    catch { case NonFatal(_) => None }
+
+}

--- a/modules/sbt-devoops-sbt-extra/src/main/scala-3/sbt/devoopsinternal/DevOopsWelcomeInternal.scala
+++ b/modules/sbt-devoops-sbt-extra/src/main/scala-3/sbt/devoopsinternal/DevOopsWelcomeInternal.scala
@@ -1,0 +1,134 @@
+package sbt.devoopsinternal
+
+import sbt.State
+
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.{AtomicBoolean, AtomicLong}
+
+import scala.util.control.NonFatal
+
+/** sbt 2 internals required to re-emit `onLoadMessage` when a client attaches to a warm server.
+  *
+  * ==Why this lives in a subpackage of `sbt`==
+  *
+  * sbt 2's `sbt` launcher is a thin client (`sbtn`). When it attaches to an already running server
+  * no project load happens, so `doLoadProject` -- which is the only thing that prints
+  * `onLoadMessage` -- never runs and the welcome banner silently disappears.
+  *
+  * Re-emitting the message means writing to the attaching client's terminal, and the only way to
+  * reach it is `sbt.StandardMain.exchange`, which is `private[sbt]`. That is a hard compile error
+  * from `package devoops` ("can only be accessed from package sbt"), not something a `try`/`catch`
+  * can rescue. Declaring this object in a subpackage of `sbt` inherits that access. Nothing else in
+  * sbt-devoops needs it: the plugin, its setting keys and the sbt 1 twin all stay in `devoops`.
+  *
+  * ==Why the package is NOT named `sbt.devoops`==
+  *
+  * `sbt.devoops` would add a `devoops` member to package `sbt`, and every file in this codebase
+  * that sits in `package devoops` and does `import sbt.*` would then resolve `devoops` to
+  * `sbt.devoops`. That breaks unrelated modules at compile time, e.g.
+  * `import devoops.data.{CommonKeys, DevOopsLogLevel}` fails with "value data is not a member of
+  * sbt.devoops". `private[sbt]` is granted to any subpackage of `sbt`, so the segment name is free
+  * as long as it differs from `devoops`.
+  *
+  * ==Stability==
+  *
+  * These internals carry no compatibility guarantee. Every use of them here is wrapped so that a
+  * future sbt change degrades to "the banner is not shown" rather than breaking the user's build.
+  *
+  * This object is sbt 2 only; there is no `scala-2` twin because nothing outside the sbt 2 compat
+  * object refers to it.
+  *
+  * @author Kevin Lee
+  * @since 2026-07-20
+  */
+object DevOopsWelcomeInternal {
+
+  /** The name of the per-channel UI thread sbt 2 runs the shell prompt on, e.g.
+    * `sbt-network-1-ui-thread`.
+    */
+  private val UiThreadPrefix: String = "sbt-"
+  private val UiThreadSuffix: String = "-ui-thread"
+
+  /** Bumped on every project load so that a `reload` re-arms the suppression below. */
+  private val loadGeneration: AtomicLong = new AtomicLong(0L)
+
+  /** Raised whenever sbt itself has just printed `onLoadMessage` during a load, so that the next
+    * prompt render suppresses the duplicate instead of printing it a second time.
+    */
+  private val suppressOnce: AtomicBoolean = new AtomicBoolean(false)
+
+  /** Channel name -> the load generation already handled for it. This is what turns a
+    * once-per-prompt-render hook into a once-per-attach one.
+    */
+  private val handledByChannel: ConcurrentHashMap[String, java.lang.Long] =
+    new ConcurrentHashMap[String, java.lang.Long]()
+
+  /** Identifies the client channel the current prompt is being rendered for.
+    *
+    * sbt 2 gives every channel its own UI thread named `sbt-<channelName>-ui-thread`, and there is
+    * no public way to obtain the channel from inside a `colorShellPrompt` function
+    * (`sbt.internal.util.Terminal.get` is `private[sbt]` and `State.currentCommand` is `None` at
+    * prompt time). Only the per-channel uniqueness of this string matters, not its exact shape.
+    */
+  def currentChannelName(): String =
+    Thread.currentThread.getName.stripPrefix(UiThreadPrefix).stripSuffix(UiThreadSuffix)
+
+  /** Called from the `onLoad` hook, i.e. exactly when sbt has loaded the project and printed
+    * `onLoadMessage` itself.
+    */
+  def onLoaded(): Unit = {
+    val _ = loadGeneration.incrementAndGet()
+    suppressOnce.set(true)
+  }
+
+  /** Whether the welcome message should be printed for `channel` on this prompt render.
+    *
+    *   - already handled this generation for this channel -> `false` (prevents printing on every
+    *     prompt render within one session)
+    *   - sbt has just printed it during a load -> `false`, consuming the flag (prevents the
+    *     duplicate on a cold start and on `reload`)
+    *   - otherwise -> `true` (a warm attach, where no load happened)
+    */
+  def shouldShow(channel: String): Boolean = {
+    val generation = loadGeneration.get()
+    val previous   = Option(handledByChannel.put(channel, java.lang.Long.valueOf(generation)))
+    if (previous.exists(_.longValue == generation)) false
+    else !suppressOnce.compareAndSet(true, false)
+  }
+
+  /** Writes directly to the given channel's terminal.
+    *
+    * `state.log.info` cannot be used here: at attach time there is no current exec, so
+    * `CommandExchange.logMessage` has no owning channel to route to, and calling it from the prompt
+    * thread deadlocks sbt. Returning the text as the prompt string does not work either -- the line
+    * editor discards it.
+    *
+    * Returns `false` (and prints nothing) if the channel is gone or sbt's internals have changed.
+    */
+  def writeTo(channel: String, message: String): Boolean =
+    try
+      sbt.StandardMain.exchange.channelForName(channel) match {
+        case Some(commandChannel) =>
+          commandChannel.terminal.printStream.println(message)
+          true
+        case None =>
+          false
+      }
+    catch {
+      case NonFatal(_) => false
+    }
+
+  /** Reproduces sbt 2's own `colorShellPrompt` default, so that overriding it to hook the welcome
+    * message leaves the prompt itself exactly as it was: a user-supplied `shellPrompt` still wins,
+    * and otherwise sbt's stock prompt is used.
+    *
+    * `shellPromptFromState` lives on `sbt.Classpaths`, not `sbt.Defaults`: `Defaults.scala` declares
+    * both objects and this one belongs to the latter.
+    */
+  def renderPrompt(shellPromptValue: State => String, isColorEnabled: Boolean, state: State): String =
+    shellPromptValue match {
+      case sbt.internal.ui.UITask.NoShellPrompt => sbt.Classpaths.shellPromptFromState(isColorEnabled)(state)
+      case userSuppliedPrompt                   => userSuppliedPrompt(state)
+    }
+
+}

--- a/modules/sbt-devoops-sbt-extra/src/main/scala/devoops/DevOopsSbtExtraPlugin.scala
+++ b/modules/sbt-devoops-sbt-extra/src/main/scala/devoops/DevOopsSbtExtraPlugin.scala
@@ -32,6 +32,12 @@ object DevOopsSbtExtraPlugin extends AutoPlugin {
       "Check if this project is the root project as well as currently selected."
     )
 
+    val devOopsAlwaysShowOnLoadMessage: SettingKey[Boolean] = settingKey[Boolean](
+      "sbt 2 only: If true, show onLoadMessage (e.g. the sbt-welcome banner) on every interactive start, " +
+        "including when sbt's thin client attaches to an already running server, which normally skips it. " +
+        "Set it at the Global scope: Global / devOopsAlwaysShowOnLoadMessage := true (default: false)"
+    )
+
     @SuppressWarnings(Array("org.wartremover.warts.Equals"))
     val commonSettings: SettingsDefinition = Def.settings(
       isRootProject := Keys.thisProjectRef.value == rootProjectRef.value,
@@ -56,6 +62,10 @@ object DevOopsSbtExtraPlugin extends AutoPlugin {
   }
 
   import autoImport.*
+
+  override def globalSettings: Seq[Def.Setting[_]] = Seq(
+    devOopsAlwaysShowOnLoadMessage := false
+  ) ++ DevOopsSbtExtraCompat.alwaysShowOnLoadMessageSettings(devOopsAlwaysShowOnLoadMessage)
 
   override def projectSettings: Seq[Def.Setting[_]] = commonSettings
 

--- a/modules/sbt-devoops-sbt-extra/src/sbt-test/sbt-devoops-sbt-extra/sbt1-noop/build.sbt
+++ b/modules/sbt-devoops-sbt-extra/src/sbt-test/sbt-devoops-sbt-extra/sbt1-noop/build.sbt
@@ -1,0 +1,15 @@
+ThisBuild / scalaVersion     := "2.12.18"
+ThisBuild / version          := "0.1.0-SNAPSHOT"
+ThisBuild / organization     := "com.example"
+ThisBuild / organizationName := "example"
+
+/* The key exists on both axes so that a shared build definition stays source compatible, but on
+ * sbt 1 it does nothing: sbt 1 has no thin client, so it always loads the project and always
+ * prints onLoadMessage.
+ */
+Global / devOopsAlwaysShowOnLoadMessage := true
+
+lazy val root = (project in file("."))
+  .settings(
+    name := "sbt1-noop"
+  )

--- a/modules/sbt-devoops-sbt-extra/src/sbt-test/sbt-devoops-sbt-extra/sbt1-noop/project/build.properties
+++ b/modules/sbt-devoops-sbt-extra/src/sbt-test/sbt-devoops-sbt-extra/sbt1-noop/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.11.7

--- a/modules/sbt-devoops-sbt-extra/src/sbt-test/sbt-devoops-sbt-extra/sbt1-noop/project/plugins.sbt
+++ b/modules/sbt-devoops-sbt-extra/src/sbt-test/sbt-devoops-sbt-extra/sbt1-noop/project/plugins.sbt
@@ -1,0 +1,5 @@
+sys.props.get("plugin.version") match {
+  case Some(x) => addSbtPlugin("io.kevinlee" % "sbt-devoops-sbt-extra" % x)
+  case _ => sys.error("""|The system property 'plugin.version' is not defined.
+                         |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+}

--- a/modules/sbt-devoops-sbt-extra/src/sbt-test/sbt-devoops-sbt-extra/sbt1-noop/src/main/scala/example/Hello.scala
+++ b/modules/sbt-devoops-sbt-extra/src/sbt-test/sbt-devoops-sbt-extra/sbt1-noop/src/main/scala/example/Hello.scala
@@ -1,0 +1,9 @@
+package example
+
+object Hello extends Greeting with App {
+  println(greeting)
+}
+
+trait Greeting {
+  lazy val greeting: String = "hello"
+}

--- a/modules/sbt-devoops-sbt-extra/src/sbt-test/sbt-devoops-sbt-extra/sbt1-noop/test
+++ b/modules/sbt-devoops-sbt-extra/src/sbt-test/sbt-devoops-sbt-extra/sbt1-noop/test
@@ -1,0 +1,6 @@
+# Setting the sbt 2 only flag on sbt 1 must be harmless: it compiles, loads and runs as usual.
+> compile
+> reload
+> compile
+> clean
+> compile

--- a/modules/sbt-devoops-sbt-extra/src/sbt-test/sbt-devoops-sbt-extra/sbt2-always-show-default-off/build.sbt
+++ b/modules/sbt-devoops-sbt-extra/src/sbt-test/sbt-devoops-sbt-extra/sbt2-always-show-default-off/build.sbt
@@ -1,0 +1,17 @@
+ThisBuild / scalaVersion     := "3.3.5"
+ThisBuild / version          := "0.1.0-SNAPSHOT"
+ThisBuild / organization     := "com.example"
+ThisBuild / organizationName := "example"
+
+lazy val checkFlagIsOffByDefault = taskKey[Unit]("Check devOopsAlwaysShowOnLoadMessage defaults to false.")
+
+lazy val root = (project in file("."))
+  .settings(
+    name := "sbt2-always-show-default-off",
+    checkFlagIsOffByDefault := Def.uncached {
+      val flag = (Global / devOopsAlwaysShowOnLoadMessage).value
+      if (flag)
+        sys.error("devOopsAlwaysShowOnLoadMessage is expected to default to false but it is true.")
+      else ()
+    },
+  )

--- a/modules/sbt-devoops-sbt-extra/src/sbt-test/sbt-devoops-sbt-extra/sbt2-always-show-default-off/project/build.properties
+++ b/modules/sbt-devoops-sbt-extra/src/sbt-test/sbt-devoops-sbt-extra/sbt2-always-show-default-off/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=2.0.1

--- a/modules/sbt-devoops-sbt-extra/src/sbt-test/sbt-devoops-sbt-extra/sbt2-always-show-default-off/project/plugins.sbt
+++ b/modules/sbt-devoops-sbt-extra/src/sbt-test/sbt-devoops-sbt-extra/sbt2-always-show-default-off/project/plugins.sbt
@@ -1,0 +1,5 @@
+sys.props.get("plugin.version") match {
+  case Some(x) => addSbtPlugin("io.kevinlee" % "sbt-devoops-sbt-extra" % x)
+  case _ => sys.error("""|The system property 'plugin.version' is not defined.
+                         |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+}

--- a/modules/sbt-devoops-sbt-extra/src/sbt-test/sbt-devoops-sbt-extra/sbt2-always-show-default-off/src/main/scala/example/Hello.scala
+++ b/modules/sbt-devoops-sbt-extra/src/sbt-test/sbt-devoops-sbt-extra/sbt2-always-show-default-off/src/main/scala/example/Hello.scala
@@ -1,0 +1,9 @@
+package example
+
+object Hello extends Greeting with App {
+  println(greeting)
+}
+
+trait Greeting {
+  lazy val greeting: String = "hello"
+}

--- a/modules/sbt-devoops-sbt-extra/src/sbt-test/sbt-devoops-sbt-extra/sbt2-always-show-default-off/test
+++ b/modules/sbt-devoops-sbt-extra/src/sbt-test/sbt-devoops-sbt-extra/sbt2-always-show-default-off/test
@@ -1,0 +1,6 @@
+# The flag must be off by default so that sbt 2's stock behaviour is unchanged
+# for anyone who has not opted in.
+> checkFlagIsOffByDefault
+# The prompt override is installed unconditionally, so the build must still work normally.
+> compile
+> checkFlagIsOffByDefault

--- a/modules/sbt-devoops-sbt-extra/src/sbt-test/sbt-devoops-sbt-extra/sbt2-always-show-enabled/build.sbt
+++ b/modules/sbt-devoops-sbt-extra/src/sbt-test/sbt-devoops-sbt-extra/sbt2-always-show-enabled/build.sbt
@@ -1,0 +1,31 @@
+ThisBuild / scalaVersion     := "3.3.5"
+ThisBuild / version          := "0.1.0-SNAPSHOT"
+ThisBuild / organization     := "com.example"
+ThisBuild / organizationName := "example"
+
+Global / devOopsAlwaysShowOnLoadMessage := true
+
+lazy val checkFlagIsOn = taskKey[Unit]("Check devOopsAlwaysShowOnLoadMessage is on.")
+
+/* The banner itself is only emitted on an interactive prompt render, which scripted cannot drive,
+ * so these tests cover the wiring: the flag applies, onLoadMessage is still readable, and the
+ * prompt override does not break loading or running the build.
+ */
+lazy val checkOnLoadMessageIsReadable = taskKey[Unit]("Check onLoadMessage is non-empty and readable.")
+
+lazy val root = (project in file("."))
+  .settings(
+    name := "sbt2-always-show-enabled",
+    checkFlagIsOn := Def.uncached {
+      val flag = (Global / devOopsAlwaysShowOnLoadMessage).value
+      if (!flag)
+        sys.error("devOopsAlwaysShowOnLoadMessage is expected to be true but it is false.")
+      else ()
+    },
+    checkOnLoadMessageIsReadable := Def.uncached {
+      val message = onLoadMessage.value
+      if (message.isEmpty)
+        sys.error("onLoadMessage is expected to be non-empty.")
+      else ()
+    },
+  )

--- a/modules/sbt-devoops-sbt-extra/src/sbt-test/sbt-devoops-sbt-extra/sbt2-always-show-enabled/project/build.properties
+++ b/modules/sbt-devoops-sbt-extra/src/sbt-test/sbt-devoops-sbt-extra/sbt2-always-show-enabled/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=2.0.1

--- a/modules/sbt-devoops-sbt-extra/src/sbt-test/sbt-devoops-sbt-extra/sbt2-always-show-enabled/project/plugins.sbt
+++ b/modules/sbt-devoops-sbt-extra/src/sbt-test/sbt-devoops-sbt-extra/sbt2-always-show-enabled/project/plugins.sbt
@@ -1,0 +1,5 @@
+sys.props.get("plugin.version") match {
+  case Some(x) => addSbtPlugin("io.kevinlee" % "sbt-devoops-sbt-extra" % x)
+  case _ => sys.error("""|The system property 'plugin.version' is not defined.
+                         |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+}

--- a/modules/sbt-devoops-sbt-extra/src/sbt-test/sbt-devoops-sbt-extra/sbt2-always-show-enabled/src/main/scala/example/Hello.scala
+++ b/modules/sbt-devoops-sbt-extra/src/sbt-test/sbt-devoops-sbt-extra/sbt2-always-show-enabled/src/main/scala/example/Hello.scala
@@ -1,0 +1,9 @@
+package example
+
+object Hello extends Greeting with App {
+  println(greeting)
+}
+
+trait Greeting {
+  lazy val greeting: String = "hello"
+}

--- a/modules/sbt-devoops-sbt-extra/src/sbt-test/sbt-devoops-sbt-extra/sbt2-always-show-enabled/test
+++ b/modules/sbt-devoops-sbt-extra/src/sbt-test/sbt-devoops-sbt-extra/sbt2-always-show-enabled/test
@@ -1,0 +1,9 @@
+# With the flag on, the build must load and behave normally. The banner itself is emitted on an
+# interactive prompt render, which scripted cannot drive, so it is verified manually instead.
+> checkFlagIsOn
+> checkOnLoadMessageIsReadable
+> compile
+# reload re-runs the load path, which is where the suppression flag is armed.
+> reload
+> checkFlagIsOn
+> compile

--- a/website/docs/sbt-extra-plugin/_category_.json
+++ b/website/docs/sbt-extra-plugin/_category_.json
@@ -1,0 +1,6 @@
+{
+  "label": "DevOopsSbtExtraPlugin",
+  "position": 7,
+  "collapsible": true,
+  "collapsed": true
+}

--- a/website/docs/sbt-extra-plugin/always-show-on-load-message.md
+++ b/website/docs/sbt-extra-plugin/always-show-on-load-message.md
@@ -1,0 +1,76 @@
+---
+id: always-show-on-load-message
+title: "DevOopsSbtExtraPlugin - Always Show the Welcome Message (sbt 2)"
+sidebar_label: "Always Show Welcome Message (sbt 2)"
+---
+
+## Why?
+
+On sbt 2, the welcome message set through `onLoadMessage` (for example the `sbt-welcome` banner that
+`DevOopsStarterPlugin` configures with the logo and the list of useful tasks) often does not appear
+when you start `sbt`. It shows up once, then seems to disappear for every later run.
+
+That is not a bug in the banner. sbt 2's `sbt` launcher is a **thin client** (`sbtn`). When an sbt
+server is already running for the build, the client simply **attaches** to it instead of loading the
+project again:
+
+```
+sbt shutdown
+sbt            # cold start: the project is loaded, the welcome message is printed
+exit
+sbt            # attaches to the running server: no load, so no welcome message
+```
+
+`onLoadMessage` is only printed while the project is being loaded, so on a warm attach it is never
+printed at all. sbt's own `welcome to sbt ...` line disappears in exactly the same situations, for
+exactly the same reason.
+
+`DevOopsSbtExtraPlugin` can re-emit the welcome message when a client attaches to an already running
+server, so it appears on every interactive start.
+
+:::note
+This is an **sbt 2 only** feature. On sbt 1 the setting exists but does nothing, because sbt 1 has no
+thin client and therefore always loads the project and always prints the message.
+:::
+
+## How to Use
+
+Set `devOopsAlwaysShowOnLoadMessage` to `true` at the `Global` scope in `build.sbt` to opt in.
+
+```sbt
+Global / devOopsAlwaysShowOnLoadMessage := true
+```
+
+Whatever `onLoadMessage` the build has configured is what gets shown, so the banner looks exactly the
+same as it does on a cold start. It is printed **once per interactive start** and is never printed
+twice: on a cold start or after a `reload`, sbt has already printed it itself, and the plugin
+suppresses the duplicate.
+
+## Setting
+
+| Setting                            | Type      | Default | Description                                                                                     |
+|:-----------------------------------|:----------|:--------|:------------------------------------------------------------------------------------------------|
+| `devOopsAlwaysShowOnLoadMessage`   | `Boolean` | `false` | sbt 2 only. Show `onLoadMessage` on every interactive start, including a warm thin-client attach. |
+
+The default is `false`, so sbt 2's stock behaviour is unchanged unless you opt in.
+
+## Limitations
+
+* **Interactive mode only.** Batch invocations such as `sbt -batch compile` or `sbt compile` that run
+  a command and exit do not render a shell prompt, so no message is shown. The message is a greeting
+  for an interactive session.
+* **sbt's own `welcome to sbt ...` line is not restored.** That line is produced inside sbt itself and
+  is out of scope here; only the `onLoadMessage` banner is re-emitted.
+* This feature relies on sbt 2 internals that carry no compatibility guarantee. Everything is written
+  so that a future sbt change degrades to "the banner is not shown" rather than breaking the build.
+
+## Alternative Without This Setting
+
+If you would rather not enable the setting, running sbt in the foreground instead of through the thin
+client also loads the project every time, so the welcome message always appears:
+
+```sbt
+sbt --server
+```
+
+The trade-off is that you lose the fast startup that the warm server gives you.


### PR DESCRIPTION
# Close #525: Add `devOopsAlwaysShowOnLoadMessage` to show the welcome message on every sbt 2 interactive start

sbt 2's launcher is a thin client, so when a server is already running for the build it just attaches instead of loading the project. `onLoadMessage` is only printed while loading (`Project.updateCurrent`, reachable solely from `doLoadProject`), so the `sbt-welcome` banner configured by `DevOopsStarterPlugin` appears on the first start and then silently disappears until the next `sbt shutdown`.

`Global / onLoad` cannot fix this: it is applied inside the same `Project.setProject` gate, so it fires on exactly the same occasions as `onLoadMessage`. The only surface that runs on a warm attach is `colorShellPrompt`, so the message is re-emitted from there, keyed by the per-channel UI thread name and guarded down to once per attach. An `onLoad` hook records when sbt has just printed the message itself, so a cold start and `reload` never print it twice.

The new flag is `false` by default, leaving stock sbt 2 behavior and the shell prompt untouched unless opted in, and it is sbt 2 only (sbt 1 has no thin client, so it always loads and always prints the message). Writing to the attaching client's terminal needs `sbt.StandardMain.exchange`, which is `private[sbt]`, so that part lives in `sbt.devoopsinternal` — deliberately not `sbt.devoops`, which would shadow the top-level `devoops` package under `import sbt.*` and break other modules. All internal usage is wrapped so a future sbt change degrades to "banner not shown" rather than a broken build.

Batch mode is out of scope since it renders no prompt, and sbt's own `welcome to sbt ...` line is not reproduced. Scripted tests cover the default-off case, the enabled wiring and the sbt 1 no-op; the warm-attach behavior itself cannot be scripted and was verified manually.
