### PR TITLE
sbt-devoops v3.7.0

### DIFF
--- a/changelogs/3.7.0.md
+++ b/changelogs/3.7.0.md
@@ -1,0 +1,23 @@
+## [3.7.0](https://github.com/kevin-lee/sbt-devoops/issues?q=is%3Aissue%20is%3Aclosed%20-label%3Adeclined%20milestone%3Am46) - 2026-07-21
+
+### New Features
+
+* [sbt 2] Add support for project-specific caching for sbt 2 (#523)
+
+  | Name                              | Type                  | Default                         | Description                                                                                       |
+  |-----------------------------------|-----------------------|---------------------------------|---------------------------------------------------------------------------------------------------|
+  | `devOopsUseLocalCache`            | `SettingKey[Boolean]` | `false`                         | Set to `true` at the `Global` scope to make sbt 2's cache build-local.                            |
+  | `devOopsBuildLocalCacheDirectory` | `SettingKey[File]`    | `<build root>/.sbt-local-cache` | The build-local cache directory.                                                                  |
+  | `devOopsCleanIncludesLocalCache`  | `SettingKey[Boolean]` | `false`                         | If `true`, `clean` also removes the build-local cache.                                            |
+  | `devOopsLocalCacheSize`           | `TaskKey[Long]`       |                                 | Show the location and the total size of the sbt local cache in use, and return the size in bytes. |
+  | `devOopsCleanLocalCache`          | Command               |                                 | Remove the build-local cache.                                                                     |
+
+* [sbt 2] Once sbt server starts, sbt console (sbt client) doesn't show `onLoadMessage` anymore (#525) - Always show onLoadMessage on sbt 2 interactive start
+
+  | Setting                          | Type      | Default | Description                                                                                       |
+  |:---------------------------------|:----------|:--------|:--------------------------------------------------------------------------------------------------|
+  | `devOopsAlwaysShowOnLoadMessage` | `Boolean` | `false` | sbt 2 only. Show `onLoadMessage` on every interactive start, including a warm thin-client attach. |
+
+### Internal Housekeeping
+
+* Unify the sbt-API-split plugin sources via sbt2-compat (#522)


### PR DESCRIPTION
# sbt-devoops v3.7.0
## [3.7.0](https://github.com/kevin-lee/sbt-devoops/issues?q=is%3Aissue%20is%3Aclosed%20-label%3Adeclined%20milestone%3Am46) - 2026-07-21

### New Features

* [sbt 2] Add support for project-specific caching for sbt 2 (#523)

  | Name                              | Type                  | Default                         | Description                                                                                       |
  |-----------------------------------|-----------------------|---------------------------------|---------------------------------------------------------------------------------------------------|
  | `devOopsUseLocalCache`            | `SettingKey[Boolean]` | `false`                         | Set to `true` at the `Global` scope to make sbt 2's cache build-local.                            |
  | `devOopsBuildLocalCacheDirectory` | `SettingKey[File]`    | `<build root>/.sbt-local-cache` | The build-local cache directory.                                                                  |
  | `devOopsCleanIncludesLocalCache`  | `SettingKey[Boolean]` | `false`                         | If `true`, `clean` also removes the build-local cache.                                            |
  | `devOopsLocalCacheSize`           | `TaskKey[Long]`       |                                 | Show the location and the total size of the sbt local cache in use, and return the size in bytes. |
  | `devOopsCleanLocalCache`          | Command               |                                 | Remove the build-local cache.                                                                     |

* [sbt 2] Once sbt server starts, sbt console (sbt client) doesn't show `onLoadMessage` anymore (#525) - Always show onLoadMessage on sbt 2 interactive start

  | Setting                          | Type      | Default | Description                                                                                       |
  |:---------------------------------|:----------|:--------|:--------------------------------------------------------------------------------------------------|
  | `devOopsAlwaysShowOnLoadMessage` | `Boolean` | `false` | sbt 2 only. Show `onLoadMessage` on every interactive start, including a warm thin-client attach. |

### Internal Housekeeping

* Unify the sbt-API-split plugin sources via sbt2-compat (#522)
